### PR TITLE
Fix corrupted Vite config file

### DIFF
--- a/frontend/src/vite.config.ts
+++ b/frontend/src/vite.config.ts
@@ -1,16 +1,13 @@
-// frontend/vite.config.ts
-
-import { define`onfig } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-e`port default define`onfig({
+export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3```,
-    pro`y: {
-      // Pro`y all /api requests to http://localhost:4```
+    port: 3000,
+    proxy: {
       "/api": {
-        target: "http://localhost:4```",
+        target: "http://localhost:4000",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- fix corrupted characters in `frontend/src/vite.config.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684cafd0a1cc83278ad3a45179a47706