### PR TITLE
Add vitest and formatAddress unit test

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,8 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",
         "typescript": "^5.8.3",
-        "vite": "^4.0.0"
+        "vite": "^4.0.0",
+        "vitest": "^1.5.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "start": "vite"
+    "start": "vite",
+    "test": "vitest"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.0.0",
@@ -27,7 +28,8 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.8.3",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^1.5.0"
   },
   "description": "",
   "main": "index.js",

--- a/frontend/src/utils/formatAddress.test.ts
+++ b/frontend/src/utils/formatAddress.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { formatAddress } from './formatAddress';
+
+describe('formatAddress', () => {
+  it('formats short address', () => {
+    expect(formatAddress('0x1234567890')).toBe('0x1234…7890');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(formatAddress('')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest test file for formatAddress util
- add vitest dev dependency and `test` script in frontend

## Testing
- `npm run test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cafd40bf8832792211f07c4cf1df5