### PR TITLE
Fix chat assistant backend

### DIFF
--- a/backend/src/services/chatbot.ts
+++ b/backend/src/services/chatbot.ts
@@ -1,7 +1,17 @@
-// File: backend/src/services/chatbot.ts
+import OpenAI from "openai";
+import { OPENAI_API_KEY } from "../utils/config";
 
-export const getChatbotResponse = (message: string): string => {
-    // TODO: Replace this logic with your real chatbot later
-    return `Echo: ${message}`;
-  };
-  
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+export async function getChatResponse(userId: string, message: string): Promise<string> {
+  // For now we ignore userId but it can be used for personalization later
+  const completion = await openai.chat.completions.create({
+    model: "gpt-3.5-turbo",
+    messages: [
+      { role: "system", content: "You are a helpful DeFi assistant." },
+      { role: "user", content: message }
+    ]
+  });
+
+  return completion.choices[0]?.message?.content || "";
+}


### PR DESCRIPTION
## Summary
- implement `getChatResponse` using OpenAI API

## Testing
- `npm run build` *(fails: cannot find module 'express' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684caff381748327b815b3bd7f4d00cf