### PR TITLE
Fix router imports and streamline server mounting

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,11 +7,11 @@ import dotenv from "dotenv";
 import jwt from "jsonwebtoken";
 
 import authRouter from "./routes/authRoutes";
-import horseRoutes from "./routes/horseRoutes";
-import userRoutes from "./routes/userRoutes";
-import earningsRoutes from "./routes/earnings";
-import transactionRoutes from "./routes/transactionRoutes";
-import chatRoutes from "./routes/chatRoutes";
+import horseRouter from "./routes/horses";
+import userRouter from "./routes/userRoutes";
+import earningsRouter from "./routes/earnings";
+import transactionRouter from "./routes/transactionRoutes";
+import chatRouter from "./routes/chatRoutes";
 
 dotenv.config();
 
@@ -24,8 +24,7 @@ mongoose
 const app = express();
 app.use(cors());
 app.use(express.json());
-app.use("/api", horseRoutes);
-app.use("/api", earningsRoutes);
+app.use("/api", earningsRouter);
 
 // Health check endpoint
 app.get("/api/health", (_req: Request, res: Response) => {
@@ -52,34 +51,14 @@ function requireAuth(req: Request, res: Response, next: NextFunction) {
 app.use("/api/auth", authRouter);
 
 // Mount horse routes (public)
-app.use("/api/horses", horseRoutes);
+app.use("/api/horses", horseRouter);
 
 // Mount protected routes
-app.use("/api/horses", requireAuth, horseRoutes);
-app.use("/api/users", requireAuth, userRoutes);
-app.use("/api/transactions", requireAuth, transactionRoutes);
-app.use("/api/chat", requireAuth, chatRoutes);
+app.use("/api/users", requireAuth, userRouter);
+app.use("/api/transactions", requireAuth, transactionRouter);
+app.use("/api/chat", requireAuth, chatRouter);
 
 const PORT = process.env.PORT || 4000;
-
-
-app.get("/api/earnings/:address", (req, res) => {
-  const { address } = req.params;
-  if (address.toLowerCase() !== "0x1462...dbee") {
-    return res.status(404).json([]);
-  }
-
-  return res.json([
-    {
-      id: "soda-pop",
-      name: "SodaPop",
-      my_share: 2.5,
-      total_earned: 13850,
-      goal: 25000,
-      progress_to_goal: 55
-    }
-  ]);
-});
 app.listen(PORT, () =>
   console.log(`🚀 Backend listening on http://localhost:${PORT}`)
 );


### PR DESCRIPTION
## Summary
- clean up duplicate route mounting in backend entrypoint
- standardize router variable names
- point horse router import to `routes/horses`

## Testing
- `npm run dev` *(fails: ts-node-dev not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cafd1eda08327b1e6656a979169bf