### PR TITLE
Restore improve script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-
+    "improve": "node scripts/improve_code.js"
   },
   "devDependencies": {
     "@truffle/hdwallet-provider": "^2.1.15",


### PR DESCRIPTION
## Summary
- fix package.json to restore the "improve" script for the self-learning model

## Testing
- `npm run improve package.json` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684fc207f5948327b6ba45c242a05ffb