### PR TITLE
Fix type errors and cleanup header

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,8 @@
     "wagmi": "^1.4.13"
   },
   "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.8.3",
     "vite": "^4.0.0",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,12 +1,10 @@
 import { Box, HStack, Heading, Spacer, Button } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
-import { Link } from "react-router-dom";
 
 const Header = () => {
   return (
     <Box p={4} bg="gray.100" boxShadow="md">
       <HStack spacing={4}>
-  <Button as={Link} to="/create" colorScheme="purple" variant="outline">Add Horse</Button>
   <Button as={Link} to="/create" colorScheme="purple" variant="outline">Add Horse</Button>
         <Heading size="md">SodaPop</Heading>
         <Spacer />

--- a/frontend/src/utils/wagmiClient.ts
+++ b/frontend/src/utils/wagmiClient.ts
@@ -1,6 +1,6 @@
 // File: frontend/src/utils/wagmiClient.ts
 
-import { configureChains, createClient } from "wagmi";
+import { configureChains, createConfig } from "wagmi";
 import { publicProvider } from "wagmi/providers/public";
 import { goerli } from "wagmi/chains"; // replace with sepolia or localhost if needed
 
@@ -9,7 +9,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
   [publicProvider()]
 );
 
-export const wagmiClient = createClient({
+export const wagmiClient = createConfig({
   autoConnect: true,
   publicClient,
   webSocketPublicClient,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL?: string;
+  readonly VITE_NFT_STORAGE_KEY?: string;
+  readonly VITE_HORSE_FACTORY_ADDRESS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add React type packages
- clean up duplicate UI markup in `Header`
- update wagmi config usage
- add `vite-env.d.ts` typings

## Testing
- `npm test --silent -- --run`


------
https://chatgpt.com/codex/tasks/task_e_685237e7e31c8327ae6211421019e68e