### PR TITLE
Fix missing metadata name when uploading horse image

### DIFF
--- a/frontend/src/pages/CreateHorse.tsx
+++ b/frontend/src/pages/CreateHorse.tsx
@@ -49,6 +49,7 @@ const CreateHorse = () => {
     });
 
     const metadata = await nftClient.store({
+      name: imageFile.name || "Uploaded Image",
       image: new NFTFile([imageFile], imageFile.name, { type: imageFile.type })
     });
 
@@ -59,6 +60,10 @@ const CreateHorse = () => {
 
   const handleSubmit = async () => {
     try {
+      if (!imageFile) {
+        alert("Please upload an image before submitting.");
+        return;
+      }
       const sharePrice = Number(form.sharePrice);
       const totalShares = Number(form.totalShares);
 


### PR DESCRIPTION
## Summary
- add `name` property when uploading to NFTStorage
- alert user when no image file is selected before submit
- run vitest unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523ea6a1388327af5b564ddbd78fcd