### PR TITLE
Improve page styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <title>SodaPop Frontend</title>
   </head>
   <body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,9 +37,9 @@ const App: React.FC = () => {
         as="header"
         px={4}
         py={2}
-        borderBottom="1px"
-        borderColor="gray.200"
-        bg="white"
+        bgGradient="linear(to-r, purple.500, pink.400)"
+        color="white"
+        boxShadow="md"
       >
         <HStack justify="space-between">
           <Heading size="md" cursor="pointer" onClick={() => navigate("/")}>
@@ -48,8 +48,9 @@ const App: React.FC = () => {
 
           <Button
             variant="ghost"
+            color="white"
             onClick={() => navigate("/")}
-            _hover={{ bg: "gray.100" }}
+            _hover={{ bg: "whiteAlpha.300" }}
             size="sm"
           >
             Horses
@@ -57,8 +58,9 @@ const App: React.FC = () => {
 
           <Button
             variant="ghost"
+            color="white"
             onClick={() => navigate("/analytics")}
-            _hover={{ bg: "gray.100" }}
+            _hover={{ bg: "whiteAlpha.300" }}
             size="sm"
           >
             Analytics
@@ -70,8 +72,13 @@ const App: React.FC = () => {
                 <Text fontSize="sm" color="gray.600">
                   Connected: {formatAddress(address)}
                 </Text>
-                <Button size="sm" onClick={() => disconnect()}>
-                  Disconnect Wallet
+                <Button
+                  size="sm"
+                  colorScheme="whiteAlpha"
+                  variant="outline"
+                  onClick={() => disconnect()}
+                >
+                  Disconnect
                 </Button>
               </>
             ) : (
@@ -83,12 +90,19 @@ const App: React.FC = () => {
                     connectLoading && connector.id === connectors?.[0]?.id
                   }
                   size="sm"
+                  colorScheme="whiteAlpha"
+                  variant="outline"
                 >
                   Connect Wallet
                 </Button>
               ))
             )}
-            <Button size="sm" onClick={handleLogout}>
+            <Button
+              size="sm"
+              colorScheme="whiteAlpha"
+              variant="outline"
+              onClick={handleLogout}
+            >
               Logout
             </Button>
           </HStack>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,57 @@
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(120deg, #f0f4ff, #fce2ff);
+  min-height: 100vh;
+  color: #333;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.chatbot {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+}
+
+.chatbot .messages {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+
+.chatbot .user {
+  text-align: right;
+  color: #3182ce;
+  margin-bottom: 0.25rem;
+}
+
+.chatbot .bot {
+  text-align: left;
+  color: #805ad5;
+  margin-bottom: 0.25rem;
+}
+
+.chatbot input {
+  width: calc(100% - 60px);
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.chatbot button {
+  background: #805ad5;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  margin-left: 0.5rem;
+  cursor: pointer;
+}
+
+.chatbot button:hover {
+  background: #6b46c1;
+}

--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -72,8 +72,10 @@ import {
     }, [address, walletClient]);
   
     return (
-      <Box>
-        <Heading size="lg" mb={4}>Your Horse Share Analytics</Heading>
+      <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+        <Heading size="lg" mb={4} color="purple.600">
+          Your Horse Share Analytics
+        </Heading>
         {loading ? (
           <Spinner />
         ) : error ? (

--- a/frontend/src/pages/CreateHorse.tsx
+++ b/frontend/src/pages/CreateHorse.tsx
@@ -104,8 +104,10 @@ const CreateHorse = () => {
   };
 
   return (
-    <Box p={6}>
-      <Heading size="lg" mb={4}>Create New Offering</Heading>
+    <Box p={6} maxW="600px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+      <Heading size="lg" mb={4} color="purple.600">
+        Create New Offering
+      </Heading>
       <VStack spacing={4} align="stretch">
 
         <Box>
@@ -143,7 +145,7 @@ const CreateHorse = () => {
           )}
         </Box>
 
-        <Button colorScheme="teal" onClick={handleSubmit}>
+        <Button colorScheme="purple" onClick={handleSubmit}>
           Create
         </Button>
       </VStack>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import Dashboard from "../components/Dashboard";
 const DashboardPage: React.FC = () => {
   return (
     <Container maxW="4xl" py={10}>
-      <Box bg="white" p={6} borderRadius="xl" shadow="lg">
+      <Box bg="whiteAlpha.800" p={6} borderRadius="xl" boxShadow="lg">
         <Dashboard userAddress="0x1462...DBee" />
       </Box>
     </Container>

--- a/frontend/src/pages/HorseDetail.tsx
+++ b/frontend/src/pages/HorseDetail.tsx
@@ -231,8 +231,10 @@ const HorseDetail: React.FC = () => {
   };
 
   return (
-    <Box p={6} maxW="700px" mx="auto">
-      <Heading mb={4}>{horse.name}</Heading>
+    <Box p={6} maxW="700px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+      <Heading mb={4} color="purple.600">
+        {horse.name}
+      </Heading>
       <Image
         src={`/images/${horse.id}.png`}
         alt={horse.name}
@@ -276,7 +278,7 @@ const HorseDetail: React.FC = () => {
 
       <HStack mt={6} spacing={4}>
         <Button
-          colorScheme="teal"
+          colorScheme="purple"
           onClick={handleBuyShare}
           isLoading={isPreparing || isMinting}
         >
@@ -287,7 +289,7 @@ const HorseDetail: React.FC = () => {
           isDisabled={mintedSoFar === 0 || mintedSoFar === null}
         >
           <Button
-            colorScheme="teal"
+            colorScheme="purple"
             variant="outline"
             size="sm"
             onClick={handleBuyEntireHorse}

--- a/frontend/src/pages/HorseList.tsx
+++ b/frontend/src/pages/HorseList.tsx
@@ -17,10 +17,10 @@ const HorseList: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <Box p={6}>
+    <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
       <HStack justify="space-between" mb={4}>
-        <Heading size="lg">Available Horses</Heading>
-        <Button as={Link} to="/create" colorScheme="purple" variant="outline">
+        <Heading size="lg" color="purple.600">Available Horses</Heading>
+        <Button as={Link} to="/create" colorScheme="purple" variant="solid">
           Add Item
         </Button>
       </HStack>
@@ -33,6 +33,8 @@ const HorseList: React.FC = () => {
             borderRadius="lg"
             justify="space-between"
             align="center"
+            bg="white"
+            boxShadow="md"
           >
             <HStack spacing={4}>
               <Image
@@ -46,7 +48,7 @@ const HorseList: React.FC = () => {
                 <Text color="gray.500">{horse.record}</Text>
               </Box>
             </HStack>
-            <Button onClick={() => navigate(`/horses/${horse.id}`)}>
+            <Button colorScheme="teal" onClick={() => navigate(`/horses/${horse.id}`)}>
               Details
             </Button>
           </HStack>


### PR DESCRIPTION
## Summary
- import Poppins font globally
- add gradient background and chatbot styles
- style header and navigation buttons with Chakra theme colors
- enhance layout of main pages with translucent boxes and shadows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852434653248327b03c64995df5441a