### PR TITLE
Refactor UI to grey theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,34 +33,23 @@ const App: React.FC = () => {
 
   return (
     <Box>
-      <Box
-        as="header"
-        px={4}
-        py={2}
-        bgGradient="linear(to-r, purple.500, pink.400)"
-        color="white"
-        boxShadow="md"
-      >
+      <Box as="header" px={4} py={2} bg="#d9d9d9" color="#000" boxShadow="md">
         <HStack justify="space-between">
           <Heading size="md" cursor="pointer" onClick={() => navigate("/")}> 
             Grey MarketPlace
           </Heading>
 
           <Button
-            variant="ghost"
-            color="white"
+            variant="grey"
             onClick={() => navigate("/")}
-            _hover={{ bg: "whiteAlpha.300" }}
             size="sm"
           >
             Horses
           </Button>
 
           <Button
-            variant="ghost"
-            color="white"
+            variant="grey"
             onClick={() => navigate("/analytics")}
-            _hover={{ bg: "whiteAlpha.300" }}
             size="sm"
           >
             Analytics
@@ -72,12 +61,7 @@ const App: React.FC = () => {
                 <Text fontSize="sm" color="gray.600">
                   Connected: {formatAddress(address)}
                 </Text>
-                <Button
-                  size="sm"
-                  colorScheme="whiteAlpha"
-                  variant="outline"
-                  onClick={() => disconnect()}
-                >
+                <Button size="sm" variant="grey" onClick={() => disconnect()}>
                   Disconnect
                 </Button>
               </>
@@ -90,19 +74,13 @@ const App: React.FC = () => {
                     connectLoading && connector.id === connectors?.[0]?.id
                   }
                   size="sm"
-                  colorScheme="whiteAlpha"
-                  variant="outline"
+                  variant="grey"
                 >
                   Connect Wallet
                 </Button>
               ))
             )}
-            <Button
-              size="sm"
-              colorScheme="whiteAlpha"
-              variant="outline"
-              onClick={handleLogout}
-            >
+            <Button size="sm" variant="grey" onClick={handleLogout}>
               Logout
             </Button>
           </HStack>

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -97,7 +97,7 @@ const ChatWindow: React.FC = () => {
                 msg.role === "system"
                   ? "gray.300"
                   : msg.role === "user"
-                  ? "blue.500"
+                  ? "#000"
                   : "gray.200"
               }
               color={msg.role === "user" ? "white" : "black"}
@@ -117,11 +117,7 @@ const ChatWindow: React.FC = () => {
           onKeyDown={handleKeyDown}
           isDisabled={isSending}
         />
-        <Button
-          colorScheme="blue"
-          onClick={sendMessage}
-          isLoading={isSending}
-        >
+        <Button variant="cta" onClick={sendMessage} isLoading={isSending}>
           Send
         </Button>
       </HStack>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -41,7 +41,7 @@ const Dashboard: React.FC<DashboardProps> = ({ userAddress }) => {
 
   return (
     <Box>
-      <Heading size="lg" mb={4}>
+      <Heading size="lg" mb={4} color="#000">
         My Racehorse Earnings
       </Heading>
       {!userAddress ? (
@@ -65,14 +65,13 @@ const Dashboard: React.FC<DashboardProps> = ({ userAddress }) => {
                   <Heading size="md">{horse.name}</Heading>
                   <Text>
                     My Ownership:{" "}
-                    <Badge colorScheme="green">{horse.my_share}%</Badge>
+                    <Badge>{horse.my_share}%</Badge>
                   </Text>
                   <Text>Total Earnings: ${horse.total_earned}</Text>
                   <Progress
                     value={horse.progress_to_goal}
                     size="sm"
                     mt={2}
-                    colorScheme="blue"
                   />
                   <Text fontSize="sm" color="gray.600">
                     Goal: ${horse.goal}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,13 +3,13 @@ import { Link } from "react-router-dom";
 
 const Header = () => {
   return (
-    <Box p={4} bg="gray.100" boxShadow="md">
+    <Box p={4} bg="#d9d9d9" boxShadow="md">
       <HStack spacing={4}>
-  <Button as={Link} to="/create" colorScheme="purple" variant="outline">Add Horse</Button>
+  <Button as={Link} to="/create" variant="cta">Add Horse</Button>
         <Heading size="md">SodaPop</Heading>
         <Spacer />
-        <Button as={Link} to="/" colorScheme="teal" variant="ghost">Dashboard</Button>
-        <Button as={Link} to="/create" colorScheme="purple" variant="outline">Add Horse</Button>
+        <Button as={Link} to="/" variant="grey">Dashboard</Button>
+        <Button as={Link} to="/create" variant="cta">Add Horse</Button>
       </HStack>
     </Box>
   );

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -76,13 +76,13 @@ const Login: React.FC = () => {
           </Text>
         )}
 
-        <Button colorScheme="blue" onClick={handleLogin} isLoading={loading}>
+        <Button variant="cta" onClick={handleLogin} isLoading={loading}>
           Login
         </Button>
 
         <Text fontSize="sm">
           Don’t have an account?{" "}
-          <Link as={RouterLink} to="/register" color="blue.500">
+          <Link as={RouterLink} to="/register" color="#000">
             Register
           </Link>
         </Text>

--- a/frontend/src/components/auth/Register.tsx
+++ b/frontend/src/components/auth/Register.tsx
@@ -71,17 +71,13 @@ const Register: React.FC = () => {
           </Text>
         )}
 
-        <Button
-          colorScheme="blue"
-          onClick={handleRegister}
-          isLoading={loading}
-        >
+        <Button variant="cta" onClick={handleRegister} isLoading={loading}>
           Register
         </Button>
 
         <Text fontSize="sm">
           Already have an account?{" "}
-          <Link as={RouterLink} to="/login" color="blue.500">
+          <Link as={RouterLink} to="/login" color="#000">
             Login
           </Link>
         </Text>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,9 @@
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
-  background: linear-gradient(120deg, #f0f4ff, #fce2ff);
+  background: #f0f0f0;
   min-height: 100vh;
-  color: #333;
+  color: #222;
 }
 
 * {
@@ -23,15 +23,16 @@ body {
   margin-bottom: 0.5rem;
 }
 
+
 .chatbot .user {
   text-align: right;
-  color: #3182ce;
+  color: #000;
   margin-bottom: 0.25rem;
 }
 
 .chatbot .bot {
   text-align: left;
-  color: #805ad5;
+  color: #333;
   margin-bottom: 0.25rem;
 }
 
@@ -43,7 +44,7 @@ body {
 }
 
 .chatbot button {
-  background: #805ad5;
+  background: #000;
   color: white;
   border: none;
   padding: 0.5rem 1rem;
@@ -53,5 +54,5 @@ body {
 }
 
 .chatbot button:hover {
-  background: #6b46c1;
+  background: #222;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
+import theme from "./theme";
 import {
   WagmiConfig,
   createConfig,
@@ -69,7 +70,7 @@ const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
     <WagmiConfig config={wagmiConfig}>
-      <ChakraProvider>
+      <ChakraProvider theme={theme}>
         <BrowserRouter>
           <App />
         </BrowserRouter>

--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -73,7 +73,7 @@ import {
   
     return (
       <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
-        <Heading size="lg" mb={4} color="purple.600">
+        <Heading size="lg" mb={4} color="#000">
           Your Horse Share Analytics
         </Heading>
         {loading ? (
@@ -92,14 +92,13 @@ import {
               >
                 <Heading size="md">{horse.name}</Heading>
                 <Text>
-                  My Ownership: <Badge colorScheme="green">{horse.my_share}%</Badge>
+                  My Ownership: <Badge>{horse.my_share}%</Badge>
                 </Text>
                 <Text>Total Earnings: ${horse.total_earned}</Text>
                 <Progress
                   value={horse.progress_to_goal}
                   size="sm"
                   mt={2}
-                  colorScheme="blue"
                 />
                 <Text fontSize="sm" color="gray.600">Goal: ${horse.goal}</Text>
               </Box>

--- a/frontend/src/pages/CreateHorse.tsx
+++ b/frontend/src/pages/CreateHorse.tsx
@@ -173,7 +173,7 @@ const CreateHorse = () => {
           </HStack>
         </Flex>
 
-        <Button colorScheme="purple" onClick={handleSubmit}>
+        <Button variant="cta" onClick={handleSubmit}>
           Create
         </Button>
       </VStack>

--- a/frontend/src/pages/HorseDetail.tsx
+++ b/frontend/src/pages/HorseDetail.tsx
@@ -243,7 +243,7 @@ const HorseDetail: React.FC = () => {
 
   return (
     <Box p={6} maxW="700px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
-      <Heading mb={4} color="purple.600">
+      <Heading mb={4} color="#000">
         {horse.name}
       </Heading>
       <Image
@@ -281,11 +281,7 @@ const HorseDetail: React.FC = () => {
       </VStack>
 
       <HStack mt={6} spacing={4}>
-        <Button
-          colorScheme="purple"
-          onClick={handleBuyShare}
-          isLoading={isPreparing || isMinting}
-        >
+        <Button variant="cta" onClick={handleBuyShare} isLoading={isPreparing || isMinting}>
           Buy Share for 0.00001 ETH
         </Button>
         <Tooltip
@@ -293,8 +289,7 @@ const HorseDetail: React.FC = () => {
           isDisabled={remainingSupply !== null && remainingSupply > 0}
         >
           <Button
-            colorScheme="purple"
-            variant="outline"
+            variant="grey"
             size="sm"
             onClick={handleBuyMax}
             isDisabled={remainingSupply !== null && remainingSupply <= 0}

--- a/frontend/src/pages/HorseList.tsx
+++ b/frontend/src/pages/HorseList.tsx
@@ -19,13 +19,13 @@ const HorseList: React.FC = () => {
   return (
     <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
       <HStack justify="space-between" mb={4}>
-        <Heading size="lg" color="purple.600">Available Horses</Heading>
-        <Button as={Link} to="/create" colorScheme="purple" variant="solid">
+        <Heading size="lg" color="#000">Available Horses</Heading>
+        <Button as={Link} to="/create" variant="cta">
           Add Item
         </Button>
       </HStack>
       <VStack spacing={6} align="stretch">
-        {horses.map((horse) => (
+        {horses.map((horse, idx) => (
           <HStack
             key={horse.id}
             p={4}
@@ -33,7 +33,7 @@ const HorseList: React.FC = () => {
             borderRadius="lg"
             justify="space-between"
             align="center"
-            bg="white"
+            bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
             boxShadow="md"
           >
             <HStack spacing={4}>
@@ -48,7 +48,7 @@ const HorseList: React.FC = () => {
                 <Text color="gray.500">{horse.record}</Text>
               </Box>
             </HStack>
-            <Button colorScheme="teal" onClick={() => navigate(`/horses/${horse.id}`)}>
+            <Button variant="grey" onClick={() => navigate(`/horses/${horse.id}`)}>
               Details
             </Button>
           </HStack>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,36 @@
+import { extendTheme } from "@chakra-ui/react";
+
+const theme = extendTheme({
+  styles: {
+    global: {
+      body: {
+        bg: "#f0f0f0",
+        color: "#222",
+      },
+    },
+  },
+  components: {
+    Button: {
+      baseStyle: {
+        borderRadius: "md",
+      },
+      variants: {
+        grey: {
+          bg: "#f0f0f0",
+          color: "#000",
+          border: "1px solid #ccc",
+          _hover: { bg: "#e0e0e0" },
+          _active: { bg: "#d9d9d9" },
+        },
+        cta: {
+          bg: "#000",
+          color: "#fff",
+          _hover: { bg: "#222" },
+          _active: { bg: "#000" },
+        },
+      },
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- add custom Chakra theme with grey palette
- restyle header and navigation buttons
- update pages and components for black/grey colors
- improve global CSS for zebra-like theme
- integrate theme in main app

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852520ff290832795950c66bff5f146