### PR TITLE
Fix JSX syntax in AnalyticsDashboard

### DIFF
--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -72,41 +72,42 @@ import {
     }, [address, walletClient]);
   
     return (
-      <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
-        <Heading size="lg" mb={4} color="purple.600">
-          Your Item Share Analytics
-        </Heading>
-        {variableAssets.length === 0 ? (
-          <Text>No share data available. Create a variable asset to get started.</Text>
-        ) : (
-          <VStack spacing={4} align="stretch">
-            {items.map((item) => (
-              <Box
-                key={item.id}
-                borderWidth="1px"
-                borderRadius="lg"
-                p={4}
-                boxShadow="lg"
-              >
-                <Heading size="md">{item.name}</Heading>
-                <Text>
-                  My Ownership: <Badge colorScheme="green">{item.my_share}%</Badge>
-                </Text>
-                <Text>Total Earnings: ${item.total_earned}</Text>
-                <Progress
-                  value={item.progress_to_goal}
-                  size="sm"
-                  mt={2}
-                  colorScheme="blue"
-                />
-                <Text fontSize="sm" color="gray.600">Goal: ${item.goal}</Text>
-              </Box>
-            ))}
-          </VStack>
-        )}
-      </Box>
-    </Box>
-  );
+      <>
+        <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+          <Heading size="lg" mb={4} color="purple.600">
+            Your Item Share Analytics
+          </Heading>
+          {variableAssets.length === 0 ? (
+            <Text>No share data available. Create a variable asset to get started.</Text>
+          ) : (
+            <VStack spacing={4} align="stretch">
+              {items.map((item) => (
+                <Box
+                  key={item.id}
+                  borderWidth="1px"
+                  borderRadius="lg"
+                  p={4}
+                  boxShadow="lg"
+                >
+                  <Heading size="md">{item.name}</Heading>
+                  <Text>
+                    My Ownership: <Badge colorScheme="green">{item.my_share}%</Badge>
+                  </Text>
+                  <Text>Total Earnings: ${item.total_earned}</Text>
+                  <Progress
+                    value={item.progress_to_goal}
+                    size="sm"
+                    mt={2}
+                    colorScheme="blue"
+                  />
+                  <Text fontSize="sm" color="gray.600">Goal: ${item.goal}</Text>
+                </Box>
+              ))}
+            </VStack>
+          )}
+        </Box>
+      </>
+    );
 };
 
 export default AnalyticsDashboard;


### PR DESCRIPTION
## Summary
- wrap AnalyticsDashboard JSX in a React fragment to avoid syntax errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68526189f9ec8327a9e397660a2f4bb7