### PR TITLE
Fix undefined variable in AnalyticsDashboard

### DIFF
--- a/frontend/src/pages/AnalyticsDashboard.tsx
+++ b/frontend/src/pages/AnalyticsDashboard.tsx
@@ -27,6 +27,10 @@ import {
     const [items, setItems] = useState<ItemStats[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
+
+    // Placeholder for variable pricing assets. Currently, our API only
+    // returns a single list of items, so use that data directly.
+    const variableAssets = items;
   
     useEffect(() => {
       const fetchAnalytics = async () => {


### PR DESCRIPTION
## Summary
- define `variableAssets` in `AnalyticsDashboard`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685262969b8c8327970078d97e350d98