### PR TITLE
Add MyItems page rendering asset cards

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import ItemList from "./pages/ItemList";
 import ItemDetail from "./pages/ItemDetail";
 import Chatbot from "./pages/Chatbot";
 import AnalyticsDashboard from "./pages/AnalyticsDashboard";
+import MyItems from "./pages/MyItems";
 
 const App: React.FC = () => {
   const { address, isConnected } = useAccount();
@@ -45,6 +46,14 @@ const App: React.FC = () => {
             size="sm"
           >
             Items
+          </Button>
+
+          <Button
+            variant="grey"
+            onClick={() => navigate("/my-items")}
+            size="sm"
+          >
+            My Items
           </Button>
 
           <Button
@@ -91,6 +100,7 @@ const App: React.FC = () => {
         <Route path="/" element={<ItemList />} />
         <Route path="/create" element={<CreateItem />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/my-items" element={<MyItems />} />
         <Route path="/items/:id" element={<ItemDetail />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
       </Routes>

--- a/frontend/src/mocks/items.json
+++ b/frontend/src/mocks/items.json
@@ -5,6 +5,25 @@
     "age": 4,
     "trainer": "Sarah Gallagher",
     "record": "12 starts – 4 wins – 5 places",
-    "earnings": "$215,300"
+    "earnings": "$215,300",
+    "image": "/images/sodapop.png"
+  },
+  {
+    "id": "ironcomet",
+    "name": "Iron Comet",
+    "age": 5,
+    "trainer": "Dave Johnson",
+    "record": "15 starts – 7 wins – 4 places",
+    "earnings": "$303,800",
+    "image": "https://via.placeholder.com/150"
+  },
+  {
+    "id": "thunderbolt",
+    "name": "Thunder Bolt",
+    "age": 3,
+    "trainer": "Amanda Lee",
+    "record": "10 starts – 3 wins – 6 places",
+    "earnings": "$123,750",
+    "image": "https://via.placeholder.com/150"
   }
 ]

--- a/frontend/src/pages/MyItems.tsx
+++ b/frontend/src/pages/MyItems.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Box, Image, Heading, Text, Button, VStack } from "@chakra-ui/react";
+import items from "../mocks/items.json";
+
+const MyItems: React.FC = () => (
+  <VStack spacing={4} align="stretch">
+    {items.map((item, idx) => (
+      <Box
+        key={idx}
+        p={4}
+        borderWidth={1}
+        borderRadius="lg"
+        boxShadow="md"
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+      >
+        <Box display="flex" alignItems="center" gap={4}>
+          <Image
+            src={item.image}
+            alt={item.name}
+            boxSize="80px"
+            borderRadius="md"
+          />
+          <Box>
+            <Heading size="md">{item.name}</Heading>
+            <Text color="gray.500">{item.record}</Text>
+          </Box>
+        </Box>
+        <Button colorScheme="teal">Details</Button>
+      </Box>
+    ))}
+  </VStack>
+);
+
+export default MyItems;


### PR DESCRIPTION
## Summary
- include new `MyItems` page for displaying a list of assets
- extend `items.json` with example horses and image links
- wire `MyItems` page into `App` routes and navigation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526aa826a48327a472b29e1a7e021e