### PR TITLE
Add ERC-1155 leaderboard API and React view

### DIFF
--- a/backend/src/controllers/leaderboard.ts
+++ b/backend/src/controllers/leaderboard.ts
@@ -1,0 +1,155 @@
+import { Router, Request, Response } from "express";
+import { ethers } from "ethers";
+import { ALCHEMY_API_URL } from "../utils/config";
+
+const router = Router();
+const provider = ALCHEMY_API_URL ? new ethers.JsonRpcProvider(ALCHEMY_API_URL) : undefined;
+
+const ERC1155_ABI = [
+  "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)",
+  "event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)",
+  "function balanceOfBatch(address[] accounts, uint256[] ids) view returns (uint256[])",
+];
+
+function getContracts(): string[] {
+  const env = process.env.GREY_CONTRACTS || "";
+  return env.split(",").map((a) => a.trim()).filter(Boolean);
+}
+
+async function fetchHolders(contractAddr: string) {
+  const iface = new ethers.Interface(ERC1155_ABI);
+  const transferSingle = iface.getEvent("TransferSingle");
+  const transferBatch = iface.getEvent("TransferBatch");
+
+  const filterSingle = {
+    address: contractAddr,
+    topics: [iface.getEventTopic(transferSingle)],
+    fromBlock: 0n,
+  } as ethers.Filter;
+  const filterBatch = {
+    address: contractAddr,
+    topics: [iface.getEventTopic(transferBatch)],
+    fromBlock: 0n,
+  } as ethers.Filter;
+
+  const logsSingle = provider ? await provider.getLogs(filterSingle) : [];
+  const logsBatch = provider ? await provider.getLogs(filterBatch) : [];
+
+  const holders = new Set<string>();
+  const tokenIds = new Set<bigint>();
+
+  for (const log of [...logsSingle, ...logsBatch]) {
+    try {
+      const parsed = iface.parseLog(log);
+      if (parsed.name === "TransferSingle") {
+        const { from, to, id } = parsed.args as any;
+        holders.add(from.toLowerCase());
+        holders.add(to.toLowerCase());
+        tokenIds.add(BigInt(id));
+      } else if (parsed.name === "TransferBatch") {
+        const { from, to, ids } = parsed.args as any;
+        holders.add(from.toLowerCase());
+        holders.add(to.toLowerCase());
+        (ids as bigint[]).forEach((i) => tokenIds.add(BigInt(i)));
+      }
+    } catch (err) {
+      console.error("Failed to parse log", err);
+    }
+  }
+
+  return { holders: Array.from(holders), tokenIds: Array.from(tokenIds) };
+}
+
+async function computeLeaderboard() {
+  const contracts = getContracts();
+  const leaderboard: Record<string, { total: bigint; unique: number; topToken: bigint; topAmount: bigint }> = {};
+
+  for (const addr of contracts) {
+    const { holders, tokenIds } = await fetchHolders(addr);
+    const contract = provider ? new ethers.Contract(addr, ERC1155_ABI, provider) : null;
+    for (const holder of holders) {
+      if (!contract) continue;
+      const accounts = tokenIds.map(() => holder);
+      const balances: bigint[] = await contract.balanceOfBatch(accounts, tokenIds);
+      let total = 0n;
+      let topToken = 0n;
+      let topAmount = 0n;
+      balances.forEach((b, idx) => {
+        total += b;
+        if (b > topAmount) {
+          topAmount = b;
+          topToken = tokenIds[idx];
+        }
+      });
+      const entry = leaderboard[holder] || { total: 0n, unique: 0, topToken: 0n, topAmount: 0n };
+      entry.total += total;
+      entry.unique += balances.filter((b) => b > 0n).length;
+      if (topAmount > entry.topAmount) {
+        entry.topAmount = topAmount;
+        entry.topToken = topToken;
+      }
+      leaderboard[holder] = entry;
+    }
+  }
+
+  const entries = Object.entries(leaderboard).map(([address, stats]) => ({
+    address,
+    totalShares: Number(stats.total),
+    uniqueAssets: stats.unique,
+    topHolding: { tokenId: String(stats.topToken), amount: Number(stats.topAmount) },
+  }));
+
+  entries.sort((a, b) => b.totalShares - a.totalShares);
+  return entries.slice(0, 5);
+}
+
+router.get("/leaderboard", async (_req: Request, res: Response) => {
+  try {
+    if (!provider) {
+      res.status(500).json({ error: "Provider not configured" });
+      return;
+    }
+    const data = await computeLeaderboard();
+    res.json(data);
+  } catch (err) {
+    console.error("Leaderboard error:", err);
+    res.status(500).json({ error: "Failed to build leaderboard" });
+  }
+});
+
+router.get("/leaderboard/test", (_req: Request, res: Response) => {
+  res.json([
+    {
+      address: "0x1111111111111111111111111111111111111111",
+      totalShares: 150,
+      uniqueAssets: 3,
+      topHolding: { tokenId: "1", amount: 100 },
+    },
+    {
+      address: "0x2222222222222222222222222222222222222222",
+      totalShares: 120,
+      uniqueAssets: 2,
+      topHolding: { tokenId: "2", amount: 80 },
+    },
+    {
+      address: "0x3333333333333333333333333333333333333333",
+      totalShares: 90,
+      uniqueAssets: 1,
+      topHolding: { tokenId: "3", amount: 90 },
+    },
+    {
+      address: "0x4444444444444444444444444444444444444444",
+      totalShares: 75,
+      uniqueAssets: 2,
+      topHolding: { tokenId: "1", amount: 40 },
+    },
+    {
+      address: "0x5555555555555555555555555555555555555555",
+      totalShares: 60,
+      uniqueAssets: 1,
+      topHolding: { tokenId: "2", amount: 60 },
+    },
+  ]);
+});
+
+export default router;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from "./controllers/auth";
 import portfolioRoutes from "./controllers/portfolio";
 import chatRoutes from "./controllers/chat";
 import marketplaceRoutes from "./controllers/marketplaceController";
+import leaderboardRoutes from "./controllers/leaderboard";
 import { PORT, JWT_SECRET } from "./utils/config";
 
 dotenv.config();
@@ -51,6 +52,9 @@ app.use("/api/chat", requireAuth, chatRoutes);
 
 // Marketplace endpoints (protected)
 app.use("/api/marketplace", requireAuth, marketplaceRoutes);
+
+// Leaderboard endpoints (unprotected)
+app.use("/api", leaderboardRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Backend listening on http://localhost:${PORT}`);

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -5,6 +5,7 @@ export const PORT = Number(process.env.PORT) || 4000;
 export const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
 export const ALCHEMY_API_URL = process.env.ALCHEMY_API_URL || "";
 export const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
+export const GREY_CONTRACTS = process.env.GREY_CONTRACTS || "";
 
 export const JWT_SECRET = process.env.JWT_SECRET || "replace_with_strong_secret";
 export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import ItemList from "./pages/ItemList";
 import ItemDetail from "./pages/ItemDetail";
 import Chatbot from "./pages/Chatbot";
 import AnalyticsDashboard from "./pages/AnalyticsDashboard";
+import LeaderboardPage from "./pages/Leaderboard";
 
 const App: React.FC = () => {
   const { address, isConnected } = useAccount();
@@ -47,13 +48,21 @@ const App: React.FC = () => {
             Items
           </Button>
 
-          <Button
-            variant="grey"
-            onClick={() => navigate("/analytics")}
-            size="sm"
-          >
-            Analytics
-          </Button>
+        <Button
+          variant="grey"
+          onClick={() => navigate("/analytics")}
+          size="sm"
+        >
+          Analytics
+        </Button>
+
+        <Button
+          variant="grey"
+          onClick={() => navigate("/leaderboard")}
+          size="sm"
+        >
+          Leaderboard
+        </Button>
 
           <HStack spacing={3}>
             {isConnected && address ? (
@@ -93,6 +102,7 @@ const App: React.FC = () => {
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/items/:id" element={<ItemDetail />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
+        <Route path="/leaderboard" element={<LeaderboardPage />} />
       </Routes>
 
       <Box position="fixed" bottom={4} right={4} zIndex={10}>

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { Box, Heading, Text, VStack, HStack, Badge, Spinner } from "@chakra-ui/react";
+import { formatAddress } from "../utils/formatAddress";
+
+interface LeaderboardEntry {
+  address: string;
+  totalShares: number;
+  uniqueAssets: number;
+  topHolding: { tokenId: string; amount: number };
+}
+
+const Leaderboard: React.FC = () => {
+  const [data, setData] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await fetch("/api/leaderboard");
+        if (!res.ok) throw new Error("Failed to fetch leaderboard");
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        console.error("Failed to load leaderboard", err);
+        setError("Unable to load leaderboard");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <Box p={6} maxW="600px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+      <Heading size="lg" mb={4} color="purple.600">
+        Share Ownership Leaderboard
+      </Heading>
+      {loading ? (
+        <Spinner />
+      ) : error ? (
+        <Text color="red.500">{error}</Text>
+      ) : (
+        <VStack spacing={3} align="stretch">
+          {data.map((entry, idx) => (
+            <HStack
+              key={entry.address}
+              p={3}
+              borderWidth={1}
+              borderRadius="md"
+              justify="space-between"
+              bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+            >
+              <HStack spacing={3}>
+                <Text fontWeight="bold">
+                  {idx === 0 ? "🥇" : idx + 1}
+                </Text>
+                <Text>{formatAddress(entry.address)}</Text>
+              </HStack>
+              <HStack spacing={4} fontSize="sm">
+                <Text>Total Shares: {entry.totalShares}</Text>
+                <Text>Unique Assets: {entry.uniqueAssets}</Text>
+                <Text>
+                  Top: <Badge colorScheme="green">{entry.topHolding.amount} of #{entry.topHolding.tokenId}</Badge>
+                </Text>
+              </HStack>
+            </HStack>
+          ))}
+        </VStack>
+      )}
+    </Box>
+  );
+};
+
+export default Leaderboard;

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import Leaderboard from "../components/Leaderboard";
+
+const LeaderboardPage: React.FC = () => {
+  return <Leaderboard />;
+};
+
+export default LeaderboardPage;


### PR DESCRIPTION
## Summary
- add new `leaderboard` controller with `/api/leaderboard` and `/api/leaderboard/test`
- expose leaderboard router in backend
- support contract list in backend config
- create React component/page to display leaderboard
- link leaderboard page in app header

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68526b8a4a4083278a8b6f4f4b71a397