### PR TITLE
Implement time-decay personalization scoring

### DIFF
--- a/backend/src/controllers/marketplaceController.ts
+++ b/backend/src/controllers/marketplaceController.ts
@@ -1,5 +1,9 @@
 import { Router, Request, Response } from "express";
-import { getRankedItems, trackUserInteraction } from "../ai/personalizationEngine";
+import {
+  getRankedItems,
+  trackUserInteraction,
+  getWalletAffinities,
+} from "../ai/personalizationEngine";
 
 const router = Router();
 
@@ -28,6 +32,18 @@ router.post("/interactions", async (req: Request, res: Response) => {
   } catch (err) {
     console.error("Track interaction error:", err);
     res.status(500).json({ error: "Failed to track interaction" });
+  }
+});
+
+// GET /api/marketplace/affinities?wallet=0x123
+router.get("/affinities", async (req: Request, res: Response) => {
+  const wallet = (req.query.wallet as string) || "";
+  try {
+    const scores = await getWalletAffinities(wallet);
+    res.json(scores);
+  } catch (err) {
+    console.error("Wallet affinities error:", err);
+    res.status(500).json({ error: "Failed to fetch affinities" });
   }
 });
 


### PR DESCRIPTION
## Summary
- weight interactions using exponential time decay
- track per-wallet affinity scores for views and purchases
- expose wallet affinities API endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68526c4e0cb48327b345e265adcec44d