### PR TITLE
Refactor variable vs fixed asset creation

### DIFF
--- a/contracts/FixedAssetToken.sol
+++ b/contracts/FixedAssetToken.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title FixedAssetToken
+ * @dev ERC-721 token representing fixed assets that are consumed or redeemed.
+ *      Tokens can be burned once the underlying asset has been used.
+ *      This contrasts with variable assets minted via ERC-1155 which remain
+ *      tradeable after purchase.
+ */
+contract FixedAssetToken is ERC721Burnable, Ownable {
+    uint256 public nextId;
+    mapping(uint256 => string) private _tokenURIs;
+
+    constructor() ERC721("FixedAsset", "FIXED") Ownable(msg.sender) {}
+
+    /**
+     * @dev Mint a new fixed asset token to `to` with the given metadata URI.
+     *      Returns the new tokenId. The token is burnable by its owner.
+     */
+    function mintFixed(address to, string memory tokenURI) external onlyOwner returns (uint256) {
+        uint256 id = nextId++;
+        _safeMint(to, id);
+        _tokenURIs[id] = tokenURI;
+        return id;
+    }
+
+    function tokenURI(uint256 id) public view override returns (string memory) {
+        return _tokenURIs[id];
+    }
+}

--- a/contracts/HorseFactory.sol
+++ b/contracts/HorseFactory.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+/**
+ * @dev Factory contract for variable assets represented by ERC-1155 tokens.
+ *      Each token ID corresponds to a fractionalized asset where `totalShares`
+ *      and `sharePrice` define its metadata. These tokens are transferable and
+ *      persist after initial sale unlike fixed assets minted via ERC-721 which
+ *      are burned once redeemed.
+ */
 contract HorseFactory is ERC1155, Ownable {
     uint256 public nextHorseId;
     address public platform;
@@ -16,6 +23,13 @@ contract HorseFactory is ERC1155, Ownable {
         platform = msg.sender;
     }
 
+    /**
+     * @notice Create a new variable asset.
+     * @dev Mints ERC-1155 tokens representing fractional ownership.
+     * @param total The total number of fractional shares.
+     * @param pricePerShare Price per share denominated by the creator.
+     * @param ipfsURI Metadata URI describing the asset.
+     */
     function createHorse(
         uint256 total,
         uint256 pricePerShare,
@@ -36,4 +50,6 @@ contract HorseFactory is ERC1155, Ownable {
     function uri(uint256 id) public view override returns (string memory) {
         return _tokenURIs[id];
     }
+
+    // Variable asset tokens persist and remain transferable after minting.
 }

--- a/frontend/src/pages/CreateItem.tsx
+++ b/frontend/src/pages/CreateItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// Asset creation page chooses between variable (ERC-1155) and fixed (ERC-721) logic
 import {
   Box,
   Heading,
@@ -15,7 +16,12 @@ import axios from "../utils/axiosConfig";
 import { useNavigate } from "react-router-dom";
 import { NFTStorage, File as NFTFile } from "nft.storage";
 import { ethers } from "ethers";
-import { HORSE_TOKEN_ADDRESS, horseTokenABI } from "../utils/contractConfig";
+import {
+  HORSE_TOKEN_ADDRESS,
+  horseTokenABI,
+  FIXED_TOKEN_ADDRESS,
+  fixedTokenABI,
+} from "../utils/contractConfig";
 
 const CreateItem = () => {
   const [form, setForm] = useState({
@@ -23,6 +29,7 @@ const CreateItem = () => {
     totalShares: ""
   });
   const [itemType, setItemType] = useState<string>("");
+  // "variable" mints ERC-1155 shares; "fixed" mints burnable ERC-721 tokens
   const [pricingMode, setPricingMode] = useState<'fixed' | 'variable'>('fixed');
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
@@ -101,13 +108,24 @@ const CreateItem = () => {
           : undefined;
       if (!provider) throw new Error("Ethereum provider not found");
       const signer = await provider.getSigner();
-      const horseToken = new ethers.Contract(
-        HORSE_TOKEN_ADDRESS,
-        horseTokenABI,
-        signer
-      );
-
-      const tx = await horseToken.createHorse(totalShares, sharePriceWei, metadataURI);
+      let tx;
+      if (pricingMode === "variable") {
+        // Variable assets mint ERC-1155 fractional tokens that remain tradeable
+        const variableToken = new ethers.Contract(
+          HORSE_TOKEN_ADDRESS,
+          horseTokenABI,
+          signer
+        );
+        tx = await variableToken.createHorse(totalShares, sharePriceWei, metadataURI);
+      } else {
+        // Fixed assets mint ERC-721 tokens which can later be burned
+        const fixedToken = new ethers.Contract(
+          FIXED_TOKEN_ADDRESS,
+          fixedTokenABI,
+          signer
+        );
+        tx = await fixedToken.mintFixed(await signer.getAddress(), metadataURI);
+      }
       await tx.wait();
 
       navigate("/dashboard");

--- a/frontend/src/utils/contractConfig.ts
+++ b/frontend/src/utils/contractConfig.ts
@@ -62,3 +62,26 @@ export const horseTokenABI = [
     ]
   }
 ];
+
+// Fixed asset (ERC-721 burnable) configuration
+export const FIXED_TOKEN_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const fixedTokenABI = [
+  {
+    type: "function",
+    name: "mintFixed",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "tokenURI", type: "string" }
+    ],
+    outputs: [{ name: "", type: "uint256" }]
+  },
+  {
+    type: "function",
+    name: "burn",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    outputs: []
+  }
+];


### PR DESCRIPTION
## Summary
- add FixedAssetToken ERC721 contract with burnable logic
- document variable asset factory lifecycle
- switch create page to use fixed or variable contracts
- expose new fixed asset contract details in config

## Testing
- `npm test --silent` in `frontend`
- `npm test` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68526c3c02008327a65963f7df88e05d