### PR TITLE
Add item embeddings and recommendation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ These assets are consumed, delivered, or redeemed upon purchase and cannot be re
 3. Copy `.env.example` to `.env` and fill in your secrets.
 4. Start the development servers:
    ```bash
-   ./dev.sh
-   ```
-   - Frontend runs at **http://localhost:5173**
-   - Backend listens on **http://localhost:4000**
+  ./dev.sh
+  ```
+  - Frontend runs at **http://localhost:5173**
+  - Backend listens on **http://localhost:4000**
+  - Personalized recommendations available at `/api/marketplace/recommendations`
 5. Compile and deploy the smart contracts (example uses Goerli):
    ```bash
    npx hardhat compile

--- a/backend/dist/ai/embeddingService.js
+++ b/backend/dist/ai/embeddingService.js
@@ -1,0 +1,89 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateEmbeddingFromText = generateEmbeddingFromText;
+exports.ensureItemEmbedding = ensureItemEmbedding;
+exports.averageUserPreferenceEmbedding = averageUserPreferenceEmbedding;
+exports.findSimilarItems = findSimilarItems;
+exports.getRecommendedItems = getRecommendedItems;
+const openai_1 = __importDefault(require("openai"));
+// Import JS models with require to avoid typing issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Item = require("../models/item");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const User = require("../models/user");
+const openai = new openai_1.default({ apiKey: process.env.OPENAI_API_KEY });
+async function generateEmbeddingFromText(text) {
+    const res = await openai.embeddings.create({
+        model: "text-embedding-3-small",
+        input: text,
+    });
+    return res.data[0].embedding;
+}
+async function ensureItemEmbedding(itemId) {
+    const item = await Item.findById(itemId);
+    if (!item)
+        return null;
+    if (Array.isArray(item.embedding) && item.embedding.length > 0) {
+        return item.embedding;
+    }
+    const embedding = await generateEmbeddingFromText(item.name);
+    item.embedding = embedding;
+    await item.save();
+    return embedding;
+}
+async function averageUserPreferenceEmbedding(wallet) {
+    const user = await User.findOne({ walletAddress: wallet }).lean();
+    if (!user || !user.interactions)
+        return null;
+    const interactedIds = Object.entries(user.interactions)
+        .filter(([, d]) => (d.favorited || 0) > 0 || (d.purchased || 0) > 0)
+        .map(([id]) => id);
+    if (interactedIds.length === 0)
+        return null;
+    const items = await Item.find({ _id: { $in: interactedIds } }).lean();
+    const embeddings = items
+        .map((i) => i.embedding)
+        .filter((e) => Array.isArray(e) && e.length > 0);
+    if (embeddings.length === 0)
+        return null;
+    const dims = embeddings[0].length;
+    const avg = new Array(dims).fill(0);
+    embeddings.forEach((vec) => {
+        for (let i = 0; i < dims; i++)
+            avg[i] += vec[i];
+    });
+    for (let i = 0; i < dims; i++)
+        avg[i] /= embeddings.length;
+    return avg;
+}
+function cosineSimilarity(a, b) {
+    let dot = 0;
+    let na = 0;
+    let nb = 0;
+    for (let i = 0; i < a.length && i < b.length; i++) {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    if (!na || !nb)
+        return 0;
+    return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+async function findSimilarItems(embedding, topN) {
+    const items = await Item.find({ embedding: { $exists: true } }).lean();
+    const scored = items.map((item) => ({
+        item,
+        score: cosineSimilarity(embedding, item.embedding),
+    }));
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, topN).map((s) => s.item);
+}
+async function getRecommendedItems(wallet, topN = 5) {
+    const userEmbedding = await averageUserPreferenceEmbedding(wallet);
+    if (!userEmbedding)
+        return [];
+    return findSimilarItems(userEmbedding, topN);
+}

--- a/backend/src/ai/embeddingService.ts
+++ b/backend/src/ai/embeddingService.ts
@@ -1,0 +1,78 @@
+import OpenAI from "openai";
+// Import JS models with require to avoid typing issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Item = require("../models/item");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const User = require("../models/user");
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function generateEmbeddingFromText(text: string): Promise<number[]> {
+  const res = await openai.embeddings.create({
+    model: "text-embedding-3-small",
+    input: text,
+  });
+  return res.data[0].embedding as unknown as number[];
+}
+
+export async function ensureItemEmbedding(itemId: string): Promise<number[] | null> {
+  const item = await Item.findById(itemId);
+  if (!item) return null;
+  if (Array.isArray(item.embedding) && item.embedding.length > 0) {
+    return item.embedding as number[];
+  }
+  const embedding = await generateEmbeddingFromText(item.name);
+  item.embedding = embedding;
+  await item.save();
+  return embedding;
+}
+
+export async function averageUserPreferenceEmbedding(wallet: string): Promise<number[] | null> {
+  const user = await User.findOne({ walletAddress: wallet }).lean();
+  if (!user || !user.interactions) return null;
+  const interactedIds = Object.entries(user.interactions)
+    .filter(([, d]: any) => (d.favorited || 0) > 0 || (d.purchased || 0) > 0)
+    .map(([id]) => id);
+  if (interactedIds.length === 0) return null;
+  const items = await Item.find({ _id: { $in: interactedIds } }).lean();
+  const embeddings = items
+    .map((i: any) => i.embedding)
+    .filter((e: any) => Array.isArray(e) && e.length > 0) as number[][];
+  if (embeddings.length === 0) return null;
+  const dims = embeddings[0].length;
+  const avg = new Array(dims).fill(0);
+  embeddings.forEach((vec) => {
+    for (let i = 0; i < dims; i++) avg[i] += vec[i];
+  });
+  for (let i = 0; i < dims; i++) avg[i] /= embeddings.length;
+  return avg;
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length && i < b.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (!na || !nb) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+export async function findSimilarItems(embedding: number[], topN: number): Promise<any[]> {
+  const items = await Item.find({ embedding: { $exists: true } }).lean();
+  const scored = items.map((item: any) => ({
+    item,
+    score: cosineSimilarity(embedding, item.embedding as number[]),
+  }));
+  scored.sort((a: any, b: any) => b.score - a.score);
+  return scored.slice(0, topN).map((s: any) => s.item);
+}
+
+export async function getRecommendedItems(wallet: string, topN = 5): Promise<any[]> {
+  const userEmbedding = await averageUserPreferenceEmbedding(wallet);
+  if (!userEmbedding) return [];
+  return findSimilarItems(userEmbedding, topN);
+}

--- a/backend/src/controllers/itemController.js
+++ b/backend/src/controllers/itemController.js
@@ -1,5 +1,6 @@
 // File: backend/src/controllers/itemController.js
 const Item = require("../models/item");
+const { ensureItemEmbedding } = require("../ai/embeddingService");
 
 exports.getAllItems = async (req, res) => {
   try {
@@ -23,6 +24,12 @@ exports.createItem = async (req, res) => {
   try {
     const newItem = new Item(req.body);
     await newItem.save();
+    // Generate and store embedding for the new item
+    try {
+      await ensureItemEmbedding(newItem._id);
+    } catch (err) {
+      console.error("Embedding generation failed:", err);
+    }
     res.status(201).json(newItem);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/backend/src/controllers/marketplaceController.ts
+++ b/backend/src/controllers/marketplaceController.ts
@@ -1,5 +1,9 @@
 import { Router, Request, Response } from "express";
-import { getRankedItems, trackUserInteraction } from "../ai/personalizationEngine";
+import {
+  getRankedItems,
+  trackUserInteraction,
+} from "../ai/personalizationEngine";
+import { getRecommendedItems } from "../ai/embeddingService";
 
 const router = Router();
 
@@ -28,6 +32,19 @@ router.post("/interactions", async (req: Request, res: Response) => {
   } catch (err) {
     console.error("Track interaction error:", err);
     res.status(500).json({ error: "Failed to track interaction" });
+  }
+});
+
+// GET /api/marketplace/recommendations?wallet=0x123&top=5
+router.get("/recommendations", async (req: Request, res: Response) => {
+  const wallet = (req.query.wallet as string) || "";
+  const top = parseInt(req.query.top as string) || 5;
+  try {
+    const items = await getRecommendedItems(wallet, top);
+    res.json(items);
+  } catch (err) {
+    console.error("Recommendation error:", err);
+    res.status(500).json({ error: "Failed to fetch recommendations" });
   }
 });
 

--- a/backend/src/models/item.js
+++ b/backend/src/models/item.js
@@ -14,6 +14,8 @@ const ItemSchema = new mongoose.Schema({
   },
   totalShares: { type: Number, required: true },
   sharesSold: { type: Number, default: 0 },
+  // Vector embedding generated from item metadata
+  embedding: { type: [Number], default: undefined },
 });
 
 module.exports = mongoose.model("Item", ItemSchema);


### PR DESCRIPTION
## Summary
- embed item metadata with OpenAI and save to MongoDB
- compute personalized recommendations from favorites and purchases
- expose `/api/marketplace/recommendations` API
- generate embeddings when creating items
- document recommendation endpoint

## Testing
- `npm --prefix backend run build`

------
https://chatgpt.com/codex/tasks/task_e_68526e9abe8c832784e571e605277763