### PR TITLE
Add vision-powered metadata generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,13 @@ These assets are consumed, delivered, or redeemed upon purchase and cannot be re
 - **Backend:** Node.js, TypeScript, Express, MongoDB
 - **Smart Contracts:** Solidity, Hardhat, Ethers.js
 - **Storage:** IPFS/Pinata for asset metadata and images
+- **AI:** OpenAI GPT-4o vision is used to auto-generate titles and descriptions
+  for uploaded images when these fields are left blank during item creation
 
 ## Environment Variables
 Copy `.env.example` to `.env` and fill in:
 - **PORT** — Backend port (default `4000`)
-- **OPENAI_API_KEY** — OpenAI key for the chatbot
+- **OPENAI_API_KEY** — OpenAI key for the chatbot and image captioning
 - **ALCHEMY_API_URL** — RPC endpoint for contract calls
 - **DEPLOYER_PRIVATE_KEY** — Private key for contract deployment
 - **JWT_SECRET** — Secret used to sign JWTs
@@ -144,6 +146,11 @@ Copy `.env.example` to `.env` and fill in:
 - **MONGO_URI** — MongoDB connection string
 - **VITE_NFT_STORAGE_KEY** — API key for nft.storage uploads
 - **VITE_HORSE_FACTORY_ADDRESS** — Deployed HorseFactory address
+
+### Auto captions with OpenAI Vision
+`POST /api/items/describe` accepts a base64 image and returns a generated title
+and short description. The item creation form uses this endpoint when the user
+leaves those fields blank.
 
 ## Deployment
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from "./controllers/auth";
 import portfolioRoutes from "./controllers/portfolio";
 import chatRoutes from "./controllers/chat";
 import marketplaceRoutes from "./controllers/marketplaceController";
+import itemsRoutes from "./routes/items";
 import leaderboardRoutes from "./controllers/leaderboard";
 import { PORT, JWT_SECRET } from "./utils/config";
 
@@ -49,6 +50,9 @@ app.use("/api", requireAuth, portfolioRoutes);
 
 // Mount chat routes (protected)
 app.use("/api/chat", requireAuth, chatRoutes);
+
+// Item creation routes (protected)
+app.use("/api/items", requireAuth, itemsRoutes);
 
 // Marketplace endpoints (protected)
 app.use("/api/marketplace", requireAuth, marketplaceRoutes);

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -1,10 +1,39 @@
 import express from "express";
+import { generateTitleAndDescription } from "../services/visionService";
 const router = express.Router();
+
+// Analyze image and return defaults
+router.post("/describe", async (req, res) => {
+  try {
+    const { image } = req.body as { image: string };
+    if (!image) {
+      res.status(400).json({ error: "Image is required" });
+      return;
+    }
+    const result = await generateTitleAndDescription(image);
+    res.json(result);
+  } catch (err) {
+    console.error("Vision describe error:", err);
+    res.status(500).json({ error: "Failed to analyze image" });
+  }
+});
 
 // POST /api/items
 router.post("/", async (req, res) => {
-  console.log("📩 New item submitted:", req.body);
-  res.status(201).json({ message: "Item received", data: req.body });
+  try {
+    let { itemType, description, image, pricingMode, sharePrice, totalShares } = req.body as any;
+    if ((!itemType || !description) && image) {
+      const generated = await generateTitleAndDescription(image);
+      if (!itemType) itemType = generated.title;
+      if (!description) description = generated.description;
+    }
+    const data = { itemType, description, image, pricingMode, sharePrice, totalShares };
+    console.log("📩 New item submitted:", data);
+    res.status(201).json({ message: "Item received", data });
+  } catch (err) {
+    console.error("Create item error:", err);
+    res.status(500).json({ error: "Failed to process item" });
+  }
 });
 
 export default router;

--- a/backend/src/services/visionService.ts
+++ b/backend/src/services/visionService.ts
@@ -1,0 +1,26 @@
+import OpenAI from "openai";
+import { OPENAI_API_KEY } from "../utils/config";
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+export async function generateTitleAndDescription(image: string): Promise<{ title: string; description: string }> {
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Provide a short title and one sentence description for the item in this image. Format as: Title: <title>\nDescription: <description>" },
+          { type: "image_url", image_url: { url: image } }
+        ] as any,
+      },
+    ],
+  });
+
+  const text = completion.choices[0]?.message?.content || "";
+  const [first, ...rest] = text.split("\n");
+  const title = first.replace(/^Title:\s*/i, "").trim();
+  const descriptionLine = rest.join(" ") || "";
+  const description = descriptionLine.replace(/^Description:\s*/i, "").trim();
+  return { title, description };
+}

--- a/frontend/src/pages/CreateItem.tsx
+++ b/frontend/src/pages/CreateItem.tsx
@@ -92,13 +92,22 @@ const CreateItem = () => {
         return;
       }
 
-      if (!description.trim()) {
-        toast({
-          status: "error",
-          title: "Missing description",
-          description: "Please provide a description for your item.",
-        });
-        return;
+      let finalType = itemType;
+      let finalDesc = description;
+      if ((!finalType || !finalDesc) && imagePreview) {
+        try {
+          const res = await axios.post("/items/describe", { image: imagePreview });
+          if (!finalType) {
+            finalType = res.data.title;
+            setItemType(res.data.title);
+          }
+          if (!finalDesc) {
+            finalDesc = res.data.description;
+            setDescription(res.data.description);
+          }
+        } catch (err) {
+          console.error("Failed to generate defaults:", err);
+        }
       }
 
       const metadataURI = await uploadToIPFS();
@@ -106,10 +115,10 @@ const CreateItem = () => {
 
       await axios.post("/items", {
         pricingMode,
-        itemType,
+        itemType: finalType,
         sharePrice: sharePriceWei.toString(),
         totalShares,
-        description,
+        description: finalDesc,
         image: metadataURI,
       });
 


### PR DESCRIPTION
## Summary
- auto-generate item titles and descriptions with OpenAI Vision
- expose `/api/items/describe` endpoint
- use the endpoint from the Create Item form
- document the new feature

## Testing
- `npm run build` in `backend`
- `npm run build` in `frontend` *(fails: Could not find a declaration file for module 'react' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68526eed40788327b922c543a1f09355