### PR TITLE
Add pages for bought and sold items

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import ItemDetail from "./pages/ItemDetail";
 import Chatbot from "./pages/Chatbot";
 import AnalyticsDashboard from "./pages/AnalyticsDashboard";
 import MyItems from "./pages/MyItems";
+import BoughtItems from "./pages/BoughtItems";
+import SoldItems from "./pages/SoldItems";
 
 const App: React.FC = () => {
   const { address, isConnected } = useAccount();
@@ -54,6 +56,22 @@ const App: React.FC = () => {
             size="sm"
           >
             My Items
+          </Button>
+
+          <Button
+            variant="grey"
+            onClick={() => navigate("/bought")}
+            size="sm"
+          >
+            My Bought Items
+          </Button>
+
+          <Button
+            variant="grey"
+            onClick={() => navigate("/sold")}
+            size="sm"
+          >
+            My Sold Items
           </Button>
 
           <Button
@@ -101,6 +119,8 @@ const App: React.FC = () => {
         <Route path="/create" element={<CreateItem />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/my-items" element={<MyItems />} />
+        <Route path="/bought" element={<BoughtItems />} />
+        <Route path="/sold" element={<SoldItems />} />
         <Route path="/items/:id" element={<ItemDetail />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
       </Routes>

--- a/frontend/src/mocks/assets.json
+++ b/frontend/src/mocks/assets.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "sodapop",
+    "name": "SodaPop",
+    "image": "/images/sodapop.png",
+    "owner": "0x1111111111111111111111111111111111111111",
+    "sharePrice": 0.02,
+    "totalShares": 10,
+    "buyers": {
+      "0x2222222222222222222222222222222222222222": 2,
+      "0x3333333333333333333333333333333333333333": 1
+    }
+  },
+  {
+    "id": "ironcomet",
+    "name": "Iron Comet",
+    "image": "https://via.placeholder.com/150",
+    "owner": "0x2222222222222222222222222222222222222222",
+    "sharePrice": 0.03,
+    "totalShares": 15,
+    "buyers": {
+      "0x1111111111111111111111111111111111111111": 5
+    }
+  },
+  {
+    "id": "thunderbolt",
+    "name": "Thunder Bolt",
+    "image": "https://via.placeholder.com/150",
+    "owner": "0x2222222222222222222222222222222222222222",
+    "sharePrice": 0.01,
+    "totalShares": 8,
+    "buyers": {
+      "0x1111111111111111111111111111111111111111": 1,
+      "0x3333333333333333333333333333333333333333": 2
+    }
+  }
+]

--- a/frontend/src/pages/BoughtItems.tsx
+++ b/frontend/src/pages/BoughtItems.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Box, Image, Heading, Text, VStack } from "@chakra-ui/react";
+import { useAccount } from "wagmi";
+import assetsData from "../mocks/assets.json";
+
+interface Asset {
+  id: string;
+  name: string;
+  image: string;
+  owner: string;
+  sharePrice: number;
+  totalShares: number;
+  buyers: Record<string, number>;
+}
+
+const assets = assetsData as unknown as Asset[];
+
+const BoughtItems: React.FC = () => {
+  const { address } = useAccount();
+  const bought = React.useMemo(() => {
+    if (!address) return [] as typeof assets;
+    return assets.filter((item) =>
+      Object.keys(item.buyers).some(
+        (b) => b.toLowerCase() === address.toLowerCase()
+      )
+    );
+  }, [address]);
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {bought.length === 0 ? (
+        <Text>No bought items found.</Text>
+      ) : (
+        bought.map((item, idx) => {
+          const key = Object.keys(item.buyers).find(
+            (b) => b.toLowerCase() === address?.toLowerCase()
+          );
+          const shares = key ? item.buyers[key] : 0;
+          const cost = shares * item.sharePrice;
+          return (
+            <Box
+              key={item.id}
+              p={4}
+              borderWidth={1}
+              borderRadius="lg"
+              boxShadow="md"
+              bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+            >
+              <Box display="flex" alignItems="center" gap={4}>
+                <Image
+                  src={item.image}
+                  alt={item.name}
+                  boxSize="80px"
+                  borderRadius="md"
+                />
+                <Box>
+                  <Heading size="md">{item.name}</Heading>
+                  <Text>Shares Owned: {shares}</Text>
+                  <Text>Price Paid: {cost} ETH</Text>
+                </Box>
+              </Box>
+            </Box>
+          );
+        })
+      )}
+    </VStack>
+  );
+};
+
+export default BoughtItems;

--- a/frontend/src/pages/SoldItems.tsx
+++ b/frontend/src/pages/SoldItems.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Box, Image, Heading, Text, VStack } from "@chakra-ui/react";
+import { useAccount } from "wagmi";
+import assetsData from "../mocks/assets.json";
+
+interface Asset {
+  id: string;
+  name: string;
+  image: string;
+  owner: string;
+  sharePrice: number;
+  totalShares: number;
+  buyers: Record<string, number>;
+}
+
+const assets = assetsData as unknown as Asset[];
+
+const SoldItems: React.FC = () => {
+  const { address } = useAccount();
+  const sold = React.useMemo(() => {
+    if (!address) return [] as typeof assets;
+    return assets.filter(
+      (item) =>
+        item.owner.toLowerCase() === address.toLowerCase() &&
+        Object.keys(item.buyers).some(
+          (b) => b.toLowerCase() !== address.toLowerCase()
+        )
+    );
+  }, [address]);
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {sold.length === 0 ? (
+        <Text>No sold items found.</Text>
+      ) : (
+        sold.map((item, idx) => {
+          const soldShares = Object.entries(item.buyers).reduce((acc, [addr, num]) => {
+            if (addr.toLowerCase() === address?.toLowerCase()) return acc;
+            return acc + (num as number);
+          }, 0);
+          const ownership = item.totalShares - soldShares;
+          return (
+            <Box
+              key={item.id}
+              p={4}
+              borderWidth={1}
+              borderRadius="lg"
+              boxShadow="md"
+              bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+            >
+              <Box display="flex" alignItems="center" gap={4}>
+                <Image
+                  src={item.image}
+                  alt={item.name}
+                  boxSize="80px"
+                  borderRadius="md"
+                />
+                <Box>
+                  <Heading size="md">{item.name}</Heading>
+                  <Text>Total Shares Sold: {soldShares}</Text>
+                  <Text>Current Ownership: {ownership}</Text>
+                </Box>
+              </Box>
+            </Box>
+          );
+        })
+      )}
+    </VStack>
+  );
+};
+
+export default SoldItems;


### PR DESCRIPTION
## Summary
- add mock asset data with buyer/owner info
- create `BoughtItems` and `SoldItems` pages
- register new routes for `/bought` and `/sold`
- update navigation to include new pages

## Testing
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68527027ee48832790ef619fdfe0006b