### PR TITLE
Add prompt token management

### DIFF
--- a/backend/src/ai/promptUtils.ts
+++ b/backend/src/ai/promptUtils.ts
@@ -1,0 +1,12 @@
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  const words = text.trim().split(/\s+/).length;
+  return Math.ceil(words * 1.3); // rough approximation
+}
+
+export function stripSensitiveValues(text: string): string {
+  if (!text) return "";
+  return text
+    .replace(/0x[a-fA-F0-9]{40}/g, "[redacted]")
+    .replace(/\b[\w.+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, "[redacted]");
+}

--- a/backend/src/controllers/chat.ts
+++ b/backend/src/controllers/chat.ts
@@ -3,7 +3,7 @@
 import { Router, Request, Response } from "express";
 import OpenAI from "openai"; // using v4+ SDK
 import { OPENAI_API_KEY } from "../utils/config";
-import { getWalletPreferences } from "../ai/personalizationEngine";
+import { buildPersonalizationPrompt } from "../ai/personalizationEngine";
 
 const MAX_PROMPT_LENGTH = 2000;
 
@@ -32,7 +32,7 @@ router.post(
         (req.query.wallet as string) ||
         (req.headers["x-wallet-address"] as string) ||
         "";
-      const pref = wallet ? await getWalletPreferences(wallet) : "";
+      const pref = wallet ? await buildPersonalizationPrompt(wallet) : "";
       const systemPrompt = sanitize(
         pref || "You are a helpful DeFi assistant.",
         MAX_PROMPT_LENGTH


### PR DESCRIPTION
## Summary
- add `promptUtils` for estimating tokens and stripping sensitive values
- generate personalization prompt with truncation
- use new prompt builder in chat controller

## Testing
- `npm run build` in backend
- `npm test` in frontend (vitest)

------
https://chatgpt.com/codex/tasks/task_e_68526f2d24b0832797b24ad21e8bb386