### PR TITLE
Add conversation history to chat

### DIFF
--- a/backend/dist/controllers/chat.js
+++ b/backend/dist/controllers/chat.js
@@ -7,6 +7,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
 const openai_1 = __importDefault(require("openai")); // using v4+ SDK
 const config_1 = require("../utils/config");
+const personalizationEngine_1 = require("../ai/personalizationEngine");
+const chatMessage_1 = __importDefault(require("../models/chatMessage"));
+const MAX_PROMPT_LENGTH = 2000;
+function sanitize(text, max = MAX_PROMPT_LENGTH) {
+    if (!text)
+        return "";
+    return text.length > max ? text.slice(0, max) : text;
+}
 const router = (0, express_1.Router)();
 const openai = new openai_1.default({ apiKey: config_1.OPENAI_API_KEY });
 // Expecting body shape: { message: { role: string; content: string } }
@@ -17,14 +25,31 @@ router.post("/message", async (req, res) => {
             res.status(400).json({ error: "Invalid request body." });
             return;
         }
-        // Send the single user message to the OpenAI chat completion endpoint.
-        // If you need full history, collect previous messages on the frontend and send them here.
+        const wallet = req.query.wallet ||
+            req.headers["x-wallet-address"] ||
+            "";
+        const pref = wallet ? await (0, personalizationEngine_1.getWalletPreferences)(wallet) : "";
+        const systemPrompt = sanitize(pref || "You are a helpful DeFi assistant.", MAX_PROMPT_LENGTH);
+        const userContent = sanitize(message.content, MAX_PROMPT_LENGTH);
+        // Load last 5 exchanges for this wallet
+        const historyDocs = wallet
+            ? await chatMessage_1.default.find({ wallet })
+                .sort({ createdAt: -1 })
+                .limit(5)
+                .lean()
+            : [];
+        const history = historyDocs
+            .reverse()
+            .map((m) => ({
+            role: m.role,
+            content: sanitize(m.content, MAX_PROMPT_LENGTH),
+        }));
         const completion = await openai.chat.completions.create({
             model: "gpt-4o-mini",
             messages: [
-                // (Optional) a system prompt could be injected here:
-                // { role: "system", content: "You are a helpful assistant." },
-                { role: message.role, content: message.content },
+                { role: "system", content: systemPrompt },
+                ...history,
+                { role: message.role, content: userContent },
             ],
         });
         const choice = completion.choices?.[0];
@@ -38,6 +63,18 @@ router.post("/message", async (req, res) => {
             role: choice.message.role,
             content: choice.message.content,
         };
+        if (wallet) {
+            await chatMessage_1.default.create({
+                wallet,
+                role: message.role,
+                content: userContent,
+            });
+            await chatMessage_1.default.create({
+                wallet,
+                role: "assistant",
+                content: reply.content,
+            });
+        }
         res.json({ reply });
     }
     catch (err) {

--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -1,5 +1,4 @@
 "use strict";
-// src/index.ts
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -8,11 +7,21 @@ const express_1 = __importDefault(require("express"));
 const cors_1 = __importDefault(require("cors"));
 const dotenv_1 = __importDefault(require("dotenv"));
 const jsonwebtoken_1 = __importDefault(require("jsonwebtoken"));
+const mongoose_1 = __importDefault(require("mongoose"));
 const auth_1 = __importDefault(require("./controllers/auth"));
 const portfolio_1 = __importDefault(require("./controllers/portfolio"));
 const chat_1 = __importDefault(require("./controllers/chat"));
+const marketplaceController_1 = __importDefault(require("./controllers/marketplaceController"));
+const leaderboard_1 = __importDefault(require("./controllers/leaderboard"));
 const config_1 = require("./utils/config");
 dotenv_1.default.config();
+// Connect to MongoDB if a URI is provided
+if (config_1.MONGO_URI) {
+    mongoose_1.default
+        .connect(config_1.MONGO_URI)
+        .then(() => console.log("✅ Connected to MongoDB"))
+        .catch((err) => console.error("Mongo connection error:", err));
+}
 const app = (0, express_1.default)();
 app.use((0, cors_1.default)());
 app.use(express_1.default.json());
@@ -24,7 +33,6 @@ app.get("/api/health", (_req, res) => {
 app.get("/api/hello", (_req, res) => {
     res.json({ message: "Hello from SodaPop backend!" });
 });
-// Middleware to protect routes with JWT
 function requireAuth(req, res, next) {
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
@@ -46,7 +54,10 @@ app.use("/api/auth", auth_1.default);
 app.use("/api", requireAuth, portfolio_1.default);
 // Mount chat routes (protected)
 app.use("/api/chat", requireAuth, chat_1.default);
-// Start server
+// Marketplace endpoints (protected)
+app.use("/api/marketplace", requireAuth, marketplaceController_1.default);
+// Leaderboard endpoint (unprotected)
+app.use("/api/leaderboard", leaderboard_1.default);
 app.listen(config_1.PORT, () => {
     console.log(`🚀 Backend listening on http://localhost:${config_1.PORT}`);
 });

--- a/backend/dist/utils/config.js
+++ b/backend/dist/utils/config.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.JWT_EXPIRES_IN = exports.JWT_SECRET = exports.PRIVATE_KEY = exports.ALCHEMY_API_URL = exports.OPENAI_API_KEY = exports.PORT = void 0;
+exports.MONGO_URI = exports.JWT_EXPIRES_IN = exports.JWT_SECRET = exports.PRIVATE_KEY = exports.ALCHEMY_API_URL = exports.OPENAI_API_KEY = exports.PORT = void 0;
 const dotenv_1 = __importDefault(require("dotenv"));
 dotenv_1.default.config();
 exports.PORT = Number(process.env.PORT) || 4000;
@@ -12,3 +12,4 @@ exports.ALCHEMY_API_URL = process.env.ALCHEMY_API_URL || "";
 exports.PRIVATE_KEY = process.env.PRIVATE_KEY || "";
 exports.JWT_SECRET = process.env.JWT_SECRET || "replace_with_strong_secret";
 exports.JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
+exports.MONGO_URI = process.env.MONGO_URI || "";

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,15 +2,24 @@ import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
 
 import authRoutes from "./controllers/auth";
 import portfolioRoutes from "./controllers/portfolio";
 import chatRoutes from "./controllers/chat";
 import marketplaceRoutes from "./controllers/marketplaceController";
 import leaderboardRoutes from "./controllers/leaderboard";
-import { PORT, JWT_SECRET } from "./utils/config";
+import { PORT, JWT_SECRET, MONGO_URI } from "./utils/config";
 
 dotenv.config();
+
+// Connect to MongoDB if a URI is provided
+if (MONGO_URI) {
+  mongoose
+    .connect(MONGO_URI)
+    .then(() => console.log("✅ Connected to MongoDB"))
+    .catch((err) => console.error("Mongo connection error:", err));
+}
 
 const app = express();
 app.use(cors());

--- a/backend/src/models/chatMessage.ts
+++ b/backend/src/models/chatMessage.ts
@@ -1,0 +1,10 @@
+import mongoose from "mongoose";
+
+const ChatMessageSchema = new mongoose.Schema({
+  wallet: { type: String, required: true },
+  role: { type: String, enum: ["user", "assistant", "system"], required: true },
+  content: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default mongoose.model("ChatMessage", ChatMessageSchema);

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -8,3 +8,4 @@ export const PRIVATE_KEY = process.env.PRIVATE_KEY || "";
 
 export const JWT_SECRET = process.env.JWT_SECRET || "replace_with_strong_secret";
 export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
+export const MONGO_URI = process.env.MONGO_URI || "";


### PR DESCRIPTION
## Summary
- persist chat messages in MongoDB
- load last 5 exchanges before sending to OpenAI
- connect backend to MongoDB via MONGO_URI

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68526f1a4524832794bb2f4157e6d52b