### PR TITLE
Add embedding utilities and recommendation engine

### DIFF
--- a/backend/src/ai/embeddingService.ts
+++ b/backend/src/ai/embeddingService.ts
@@ -1,0 +1,54 @@
+import OpenAI from "openai";
+// Import JS models with require to avoid typing issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Item = require("../models/item");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const User = require("../models/user");
+import { OPENAI_API_KEY } from "../utils/config";
+import { cosineSimilarity, averageVectors } from "../utils/vectorMath";
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+export async function getRecommendedItems(
+  wallet: string,
+  top: number
+): Promise<any[]> {
+  const allItems = (await Item.find().lean()) as any[];
+  if (!wallet) return allItems.slice(0, top);
+
+  const user = await User.findOne({ walletAddress: wallet }).lean();
+  if (!user || !user.interactions) {
+    return allItems.slice(0, top);
+  }
+  const interactedIds = Object.entries(user.interactions)
+    .filter(([, d]: any) => (d.favorited || 0) > 0 || (d.purchased || 0) > 0)
+    .map(([id]) => id);
+
+  const itemMap = new Map(allItems.map((it: any) => [String(it._id), it]));
+  const vectors: number[][] = [];
+  for (const id of interactedIds) {
+    const item = itemMap.get(id);
+    if (item && Array.isArray(item.embedding) && item.embedding.length) {
+      vectors.push(item.embedding);
+    }
+  }
+
+  if (!vectors.length) {
+    return allItems.slice(0, top);
+  }
+
+  const userVector = averageVectors(vectors);
+  if (!userVector.length) {
+    return allItems.slice(0, top);
+  }
+
+  const scored = allItems.map((it: any) => {
+    const score = cosineSimilarity(userVector, it.embedding || []);
+    return { item: it, score };
+  });
+
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, top)
+    .map((s) => s.item);
+}

--- a/backend/src/jobs/generateItemEmbeddings.ts
+++ b/backend/src/jobs/generateItemEmbeddings.ts
@@ -1,0 +1,44 @@
+import mongoose from "mongoose";
+import OpenAI from "openai";
+import dotenv from "dotenv";
+const Item = require("../models/item");
+import { OPENAI_API_KEY } from "../utils/config";
+
+dotenv.config();
+
+const MONGO_URI = process.env.MONGO_URI || "";
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+async function main() {
+  await mongoose.connect(MONGO_URI);
+
+  const items = await Item.find({ $or: [{ embedding: { $exists: false } }, { embedding: { $size: 0 } }] });
+  if (!items.length) {
+    console.log("No items require embeddings");
+    await mongoose.disconnect();
+    return;
+  }
+
+  const batchSize = 50;
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const inputs = batch.map((it: any) => it.description || it.name || "");
+    const res = await openai.embeddings.create({
+      model: "text-embedding-3-small",
+      input: inputs,
+    });
+    res.data.forEach((d, idx) => {
+      batch[idx].embedding = d.embedding;
+    });
+    await Promise.all(batch.map((doc: any) => doc.save()));
+    console.log(`Processed ${Math.min(i + batch.length, items.length)} / ${items.length}`);
+  }
+
+  await mongoose.disconnect();
+  console.log("Done");
+}
+
+main().catch((err) => {
+  console.error(err);
+  mongoose.disconnect();
+});

--- a/backend/src/models/item.js
+++ b/backend/src/models/item.js
@@ -14,6 +14,8 @@ const ItemSchema = new mongoose.Schema({
   },
   totalShares: { type: Number, required: true },
   sharesSold: { type: Number, default: 0 },
+  // Vector embedding for recommendation engine
+  embedding: { type: [Number], default: undefined },
 });
 
 module.exports = mongoose.model("Item", ItemSchema);

--- a/backend/src/utils/vectorMath.ts
+++ b/backend/src/utils/vectorMath.ts
@@ -1,0 +1,35 @@
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || b.length === 0) {
+    return 0;
+  }
+  if (a.length !== b.length) {
+    return 0;
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / Math.sqrt(normA * normB);
+}
+
+export function averageVectors(vectors: number[][]): number[] {
+  if (!Array.isArray(vectors) || vectors.length === 0) return [];
+  const length = vectors[0].length;
+  for (const v of vectors) {
+    if (!Array.isArray(v) || v.length !== length) {
+      return [];
+    }
+  }
+  const sum = new Array(length).fill(0);
+  for (const v of vectors) {
+    for (let i = 0; i < length; i++) {
+      sum[i] += v[i];
+    }
+  }
+  return sum.map((x) => x / vectors.length);
+}


### PR DESCRIPTION
## Summary
- add `embedding` field to Item schema
- create vector math helpers
- implement item recommendation service
- add script to generate embeddings for items

## Testing
- `npm --prefix backend run build`

------
https://chatgpt.com/codex/tasks/task_e_6852736b57648327a2ab1943c75d8a26