### PR TITLE
Add pages for my bought and sold items

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,8 @@ import AnalyticsDashboard from "./pages/AnalyticsDashboard";
 import MyItems from "./pages/MyItems";
 import BoughtItems from "./pages/BoughtItems";
 import SoldItems from "./pages/SoldItems";
+import MyBoughtItems from "./pages/MyBoughtItems";
+import MySoldItems from "./pages/MySoldItems";
 
 const App: React.FC = () => {
   const { address, isConnected } = useAccount();
@@ -121,6 +123,8 @@ const App: React.FC = () => {
         <Route path="/my-items" element={<MyItems />} />
         <Route path="/bought" element={<BoughtItems />} />
         <Route path="/sold" element={<SoldItems />} />
+        <Route path="/my-bought-items" element={<MyBoughtItems />} />
+        <Route path="/my-sold-items" element={<MySoldItems />} />
         <Route path="/items/:id" element={<ItemDetail />} />
         <Route path="/analytics" element={<AnalyticsDashboard />} />
       </Routes>

--- a/frontend/src/pages/MyBoughtItems.tsx
+++ b/frontend/src/pages/MyBoughtItems.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import {
+  Box,
+  Heading,
+  VStack,
+  HStack,
+  Image,
+  Text,
+  Button,
+} from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+
+interface Item {
+  name: string;
+  image: string;
+  starts: number;
+  wins: number;
+  places: number;
+}
+
+const items: Item[] = [
+  {
+    name: "Thunder Bolt",
+    image: "https://via.placeholder.com/150",
+    starts: 10,
+    wins: 3,
+    places: 6,
+  },
+  {
+    name: "Iron Comet",
+    image: "https://via.placeholder.com/150",
+    starts: 15,
+    wins: 7,
+    places: 4,
+  },
+];
+
+const MyBoughtItems: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+      <Heading size="lg" color="purple.600" mb={4}>
+        My Bought Items
+      </Heading>
+      <VStack spacing={6} align="stretch">
+        {items.map((item, idx) => (
+          <HStack
+            key={idx}
+            p={4}
+            borderWidth={1}
+            borderRadius="lg"
+            justify="space-between"
+            align="center"
+            bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+            boxShadow="md"
+          >
+            <HStack spacing={4} align="center">
+              <Image src={item.image} alt={item.name} boxSize="100px" borderRadius="md" />
+              <Box>
+                <Heading size="md">{item.name}</Heading>
+                <Text color="gray.500">
+                  {item.starts} starts – {item.wins} wins – {item.places} places
+                </Text>
+              </Box>
+            </HStack>
+            <Button colorScheme="teal" onClick={() => navigate("/items/" + idx)}>
+              Details
+            </Button>
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default MyBoughtItems;

--- a/frontend/src/pages/MySoldItems.tsx
+++ b/frontend/src/pages/MySoldItems.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import {
+  Box,
+  Heading,
+  VStack,
+  HStack,
+  Image,
+  Text,
+  Button,
+} from "@chakra-ui/react";
+import { useNavigate } from "react-router-dom";
+
+interface Item {
+  name: string;
+  image: string;
+  starts: number;
+  wins: number;
+  places: number;
+}
+
+const items: Item[] = [
+  {
+    name: "SodaPop",
+    image: "/images/sodapop.png",
+    starts: 12,
+    wins: 4,
+    places: 5,
+  },
+  {
+    name: "Thunder Bolt",
+    image: "https://via.placeholder.com/150",
+    starts: 8,
+    wins: 2,
+    places: 3,
+  },
+];
+
+const MySoldItems: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+      <Heading size="lg" color="purple.600" mb={4}>
+        My Sold Items
+      </Heading>
+      <VStack spacing={6} align="stretch">
+        {items.map((item, idx) => (
+          <HStack
+            key={idx}
+            p={4}
+            borderWidth={1}
+            borderRadius="lg"
+            justify="space-between"
+            align="center"
+            bg={idx % 2 === 0 ? "#fff" : "#f8f8f8"}
+            boxShadow="md"
+          >
+            <HStack spacing={4} align="center">
+              <Image src={item.image} alt={item.name} boxSize="100px" borderRadius="md" />
+              <Box>
+                <Heading size="md">{item.name}</Heading>
+                <Text color="gray.500">
+                  {item.starts} starts – {item.wins} wins – {item.places} places
+                </Text>
+              </Box>
+            </HStack>
+            <Button colorScheme="teal" onClick={() => navigate("/items/" + idx)}>
+              Details
+            </Button>
+          </HStack>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default MySoldItems;


### PR DESCRIPTION
## Summary
- list bought items in `MyBoughtItems` page using mock data
- list sold items in `MySoldItems` page using mock data
- register the new pages in `App` routing

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68527d2c744c8327b4eff5c690792b28