### PR TITLE
Add welcome page and update routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { clearToken } from "./utils/authToken";
 import { formatAddress } from "./utils/formatAddress";
 import ItemList from "./pages/ItemList";
+import Welcome from "./pages/Welcome";
 import ItemDetail from "./pages/ItemDetail";
 import Chatbot from "./pages/Chatbot";
 import AnalyticsDashboard from "./pages/AnalyticsDashboard";
@@ -46,7 +47,7 @@ const App: React.FC = () => {
 
           <Button
             variant="grey"
-            onClick={() => navigate("/")}
+            onClick={() => navigate("/items")}
             size="sm"
           >
             Items
@@ -117,7 +118,8 @@ const App: React.FC = () => {
       </Box>
 
       <Routes>
-        <Route path="/" element={<ItemList />} />
+        <Route path="/" element={<Welcome />} />
+        <Route path="/items" element={<ItemList />} />
         <Route path="/create" element={<CreateItem />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/my-items" element={<MyItems />} />

--- a/frontend/src/pages/Welcome.tsx
+++ b/frontend/src/pages/Welcome.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box, Heading, Text, VStack } from '@chakra-ui/react';
+
+const Welcome: React.FC = () => (
+  <Box p={6} maxW="800px" mx="auto" bg="whiteAlpha.800" borderRadius="lg" boxShadow="lg">
+    <VStack spacing={4} align="start">
+      <Heading size="lg" color="purple.600">
+        Welcome to Grey MarketPlace
+      </Heading>
+      <Text>
+        Grey MarketPlace is a decentralized marketplace for creating, buying, and selling both variable and fixed assets. It combines Web3-powered investment infrastructure with on-chain commerce fulfillment.
+      </Text>
+      <Text>
+        Variable assets provide ongoing fractional ownership via tokenized shares, while fixed assets enable one-time purchases. Explore the market to discover a variety of tokenized real-world assets.
+      </Text>
+    </VStack>
+  </Box>
+);
+
+export default Welcome;


### PR DESCRIPTION
## Summary
- add `Welcome` page describing Grey MarketPlace
- set `Welcome` as the default route and move items list to `/items`
- update navigation button to link to `/items`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` in `frontend`
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685284d5f8188327ac0fa3e1934a9e6a