### PR TITLE
Add search and analytics features

### DIFF
--- a/backend/src/ai/insightsService.ts
+++ b/backend/src/ai/insightsService.ts
@@ -1,0 +1,41 @@
+// Aggregates user interaction data to derive insights for sellers
+import { Model } from "mongoose";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const User = require("../models/user");
+
+export interface ItemInsight {
+  itemId: string;
+  views: number;
+  favorites: number;
+  purchases: number;
+  uniqueUsers: number;
+}
+
+export async function generateItemInsights(): Promise<ItemInsight[]> {
+  const users = await User.find().lean();
+  const map: Record<string, { views: number; favorites: number; purchases: number; users: Set<string> }> = {};
+
+  for (const user of users) {
+    const wallet = String((user as any).walletAddress || "");
+    const interactions = (user as any).interactions || {};
+    for (const [itemId, data] of Object.entries(interactions) as [string, any][]) {
+      if (!map[itemId]) {
+        map[itemId] = { views: 0, favorites: 0, purchases: 0, users: new Set() };
+      }
+      map[itemId].views += data.viewed || 0;
+      map[itemId].favorites += data.favorited || 0;
+      map[itemId].purchases += data.purchased || 0;
+      map[itemId].users.add(wallet);
+    }
+  }
+
+  return Object.entries(map)
+    .map(([itemId, data]) => ({
+      itemId,
+      views: data.views,
+      favorites: data.favorites,
+      purchases: data.purchases,
+      uniqueUsers: data.users.size,
+    }))
+    .sort((a, b) => b.purchases - a.purchases || b.views - a.views);
+}

--- a/backend/src/ai/searchService.ts
+++ b/backend/src/ai/searchService.ts
@@ -1,0 +1,37 @@
+import OpenAI from "openai";
+import { OPENAI_API_KEY } from "../utils/config";
+// Import JS models with require to avoid typing issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Item = require("../models/item");
+import { cosineSimilarity } from "../utils/vectorMath";
+import { getWalletAffinities } from "./personalizationEngine";
+
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+export async function searchItems(
+  query: string,
+  wallet = "",
+  top = 10
+): Promise<any[]> {
+  if (!query) return [];
+  const allItems = (await Item.find().lean()) as any[];
+  if (!allItems.length) return [];
+
+  const embed = await openai.embeddings.create({
+    model: "text-embedding-3-small",
+    input: query,
+  });
+  const queryVec = embed.data[0]?.embedding || [];
+  if (!queryVec.length) return allItems.slice(0, top);
+
+  const affinities = wallet ? await getWalletAffinities(wallet) : {};
+  const scored = allItems.map((it: any) => {
+    const sim = cosineSimilarity(queryVec, it.embedding || []);
+    const affinity = affinities[String(it._id)] || 0;
+    return { item: it, score: sim + affinity };
+  });
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, top)
+    .map((s) => s.item);
+}

--- a/backend/src/controllers/marketplaceController.ts
+++ b/backend/src/controllers/marketplaceController.ts
@@ -5,6 +5,8 @@ import {
   getWalletAffinities,
 } from "../ai/personalizationEngine";
 import { getRecommendedItems } from "../ai/embeddingService";
+import { searchItems } from "../ai/searchService";
+import { generateItemInsights } from "../ai/insightsService";
 
 const router = Router();
 
@@ -49,6 +51,20 @@ router.get("/recommendations", async (req: Request, res: Response) => {
   }
 });
 
+// GET /api/marketplace/search?q=horse&wallet=0x123&top=5
+router.get("/search", async (req: Request, res: Response) => {
+  const wallet = (req.query.wallet as string) || "";
+  const top = parseInt(req.query.top as string) || 5;
+  const q = (req.query.q as string) || "";
+  try {
+    const items = await searchItems(q, wallet, top);
+    res.json(items);
+  } catch (err) {
+    console.error("Search error:", err);
+    res.status(500).json({ error: "Failed to search items" });
+  }
+});
+
 // GET /api/marketplace/affinities?wallet=0x123
 router.get("/affinities", async (req: Request, res: Response) => {
   const wallet = (req.query.wallet as string) || "";
@@ -58,6 +74,17 @@ router.get("/affinities", async (req: Request, res: Response) => {
   } catch (err) {
     console.error("Wallet affinities error:", err);
     res.status(500).json({ error: "Failed to fetch affinities" });
+  }
+});
+
+// GET /api/marketplace/insights
+router.get("/insights", async (_req: Request, res: Response) => {
+  try {
+    const insights = await generateItemInsights();
+    res.json(insights);
+  } catch (err) {
+    console.error("Insights error:", err);
+    res.status(500).json({ error: "Failed to generate insights" });
   }
 });
 


### PR DESCRIPTION
## Summary
- provide a search service using OpenAI embeddings
- derive simple insights from user interactions
- expose new `/search` and `/insights` marketplace routes

## Testing
- `npm run build` (backend)
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685309af7ac483278c5fb37068785d2a