### PR TITLE
Implement SodaBot chat support

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 import authRoutes from "./controllers/auth";
 import portfolioRoutes from "./controllers/portfolio";
 import chatRoutes from "./controllers/chat";
+import sodabotRoutes from "./routes/sodabot";
 import marketplaceRoutes from "./controllers/marketplaceController";
 import itemsRoutes from "./routes/items";
 import leaderboardRoutes from "./controllers/leaderboard";
@@ -73,6 +74,9 @@ app.use("/api", requireAuth, eventRoutes);
 
 // Leaderboard endpoint (unprotected)
 app.use("/api/leaderboard", leaderboardRoutes);
+
+// SodaBot chat endpoint (unprotected)
+app.use("/api/sodabot", sodabotRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Backend listening on http://localhost:${PORT}`);

--- a/backend/src/routes/sodabot.ts
+++ b/backend/src/routes/sodabot.ts
@@ -1,0 +1,34 @@
+import express from "express";
+import OpenAI from "openai";
+
+const router = express.Router();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || "" });
+
+router.post("/", async (req, res) => {
+  try {
+    const { prompt } = req.body as { prompt?: string };
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are SodaBot, a helpful assistant for horse trading and NFT data.",
+        },
+        { role: "user", content: prompt ?? "" },
+      ],
+    });
+
+    const reply =
+      completion.choices[0]?.message?.content ||
+      "I couldn't generate a response.";
+    res.json({ reply });
+  } catch (err) {
+    console.error("SodaBot error:", err);
+    res.status(500).json({ error: "Failed to respond." });
+  }
+});
+
+export default router;

--- a/frontend/src/components/SodaBot.tsx
+++ b/frontend/src/components/SodaBot.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import axios from "axios";
+
+const SodaBot = () => {
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<{ from: string; text: string }[]>([]);
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+
+    const userMessage = { from: "user", text: input };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+
+    try {
+      const res = await axios.post("/api/sodabot", { prompt: input });
+      const botMessage = { from: "bot", text: res.data.reply };
+      setMessages((prev) => [...prev, botMessage]);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        { from: "bot", text: "⚠️ SodaBot failed to reply." },
+      ]);
+    }
+  };
+
+  return (
+    <div className="border rounded p-4 w-full max-w-md mx-auto bg-white">
+      <div className="mb-4 h-48 overflow-y-auto border p-2 bg-gray-50 rounded">
+        {messages.map((msg, i) => (
+          <div
+            key={i}
+            className={`text-sm mb-1 ${msg.from === "bot" ? "text-purple-700" : "text-gray-800"}`}
+          >
+            <strong>{msg.from === "bot" ? "SodaBot" : "You"}:</strong> {msg.text}
+          </div>
+        ))}
+      </div>
+      <input
+        type="text"
+        placeholder="Ask SodaBot..."
+        className="w-full border p-2 rounded mb-2"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <button
+        onClick={handleSend}
+        className="w-full bg-black text-white py-2 rounded hover:bg-gray-900 transition"
+      >
+        Send
+      </button>
+    </div>
+  );
+};
+
+export default SodaBot;

--- a/frontend/src/pages/Chatbot.tsx
+++ b/frontend/src/pages/Chatbot.tsx
@@ -1,57 +1,8 @@
-// File: frontend/src/pages/Chatbot.tsx
-// Place this into: ~/SodaPop/frontend/src/pages/Chatbot.tsx
-
-import React, { useState } from "react";
-import api from "../utils/api";
-import { getToken } from "../utils/authToken";
-
-interface Message {
-  sender: "user" | "bot";
-  text: string;
-}
+import React from "react";
+import SodaBot from "../components/SodaBot";
 
 const Chatbot: React.FC = () => {
-  const [input, setInput] = useState<string>("");
-  const [messages, setMessages] = useState<Message[]>([]);
-
-  const sendMessage = async () => {
-    if (!input.trim()) return;
-    const userMsg: Message = { sender: "user", text: input };
-    setMessages((prev) => [...prev, userMsg]);
-    setInput("");
-
-    const token = getToken();
-    const res = await api.post<{ reply: { role: string; content: string } }>(
-      "/chat/message",
-      {
-        message: { role: "user", content: userMsg.text },
-      },
-      {
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-      }
-    );
-    const botMsg: Message = { sender: "bot", text: res.data.reply.content };
-    setMessages((prev) => [...prev, botMsg]);
-  };
-
-  return (
-    <div className="chatbot">
-      <div className="messages">
-        {messages.map((m, idx) => (
-          <div key={idx} className={m.sender}>
-            {m.text}
-          </div>
-        ))}
-      </div>
-      <input
-        type="text"
-        value={input}
-        onChange={(e) => setInput(e.target.value)}
-        placeholder="Ask SodaBot..."
-      />
-      <button onClick={sendMessage}>Send</button>
-    </div>
-  );
+  return <SodaBot />;
 };
 
 export default Chatbot;


### PR DESCRIPTION
## Summary
- add `/api/sodabot` backend route using OpenAI
- expose SodaBot route in Express app
- create SodaBot React component that posts to the new API
- simplify Chatbot page to render the new component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685331751f6c8327ad6839ae7dadd132