### PR TITLE
Implement enhanced Sodabot route

### DIFF
--- a/backend/src/routes/sodabot.ts
+++ b/backend/src/routes/sodabot.ts
@@ -1,13 +1,59 @@
-import express from "express";
+import express, { Request, Response } from "express";
 import OpenAI from "openai";
 
-const router = express.Router();
+// Import JS models with require to avoid typing issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Item = require("../models/item");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Transaction = require("../models/transaction");
+
+const router: express.Router = express.Router();
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || "" });
 
-router.post("/", async (req, res) => {
+router.post("/", async (req: Request, res: Response) => {
   try {
-    const { prompt } = req.body as { prompt?: string };
+    const { prompt, userAddress } = req.body as {
+      prompt?: string;
+      userAddress?: string;
+    };
+
+    if (!prompt || !userAddress) {
+      res.status(400).json({ error: "Missing prompt or user address." });
+      return;
+    }
+
+    // Look up items the user has interacted with
+    let boughtItems: any[] = [];
+    let soldItems: any[] = [];
+
+    try {
+      const userModel = require("../models/user");
+      const user = await userModel
+        .findOne({ walletAddress: userAddress.toLowerCase() })
+        .lean();
+      if (user) {
+        const boughtIds = await Transaction.find({ userId: user._id }).distinct(
+          "itemId"
+        );
+        boughtItems = await Item.find({ _id: { $in: boughtIds } }).lean();
+      }
+    } catch (err) {
+      console.error("Failed to fetch bought items", err);
+    }
+
+    try {
+      soldItems = await Item.find({ seller: userAddress.toLowerCase() }).lean();
+    } catch (err) {
+      console.error("Failed to fetch sold items", err);
+    }
+
+    const insight = {
+      boughtCount: boughtItems.length,
+      soldCount: soldItems.length,
+      topPerformer: soldItems.sort((a, b) => (b.wins || 0) - (a.wins || 0))[0]?.
+        name,
+    };
 
     const completion = await openai.chat.completions.create({
       model: "gpt-4",
@@ -15,9 +61,16 @@ router.post("/", async (req, res) => {
         {
           role: "system",
           content:
-            "You are SodaBot, a helpful assistant for horse trading and NFT data.",
+            "You are SodaBot, an intelligent assistant for users of Grey MarketPlace. You summarize sales, ownership history, performance stats, and make helpful suggestions.",
         },
-        { role: "user", content: prompt ?? "" },
+        {
+          role: "user",
+          content: `${prompt}\n\nUser Address: ${userAddress}\nItems Bought: ${boughtItems
+            .map((i) => i.name)
+            .join(", ")}\nItems Sold: ${soldItems
+            .map((i) => i.name)
+            .join(", ")}\nTop Performer: ${insight.topPerformer}`,
+        },
       ],
     });
 
@@ -27,7 +80,7 @@ router.post("/", async (req, res) => {
     res.json({ reply });
   } catch (err) {
     console.error("SodaBot error:", err);
-    res.status(500).json({ error: "Failed to respond." });
+    res.status(500).json({ error: "SodaBot failed to respond." });
   }
 });
 

--- a/frontend/src/components/SodaBot.tsx
+++ b/frontend/src/components/SodaBot.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import axios from "axios";
+import { useAccount } from "wagmi";
 
 const SodaBot = () => {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<{ from: string; text: string }[]>([]);
+  const { address } = useAccount();
 
   const handleSend = async () => {
     if (!input.trim()) return;
@@ -13,7 +15,10 @@ const SodaBot = () => {
     setInput("");
 
     try {
-      const res = await axios.post("/api/sodabot", { prompt: input });
+      const res = await axios.post("/api/sodabot", {
+        prompt: input,
+        userAddress: address?.toLowerCase(),
+      });
       const botMessage = { from: "bot", text: res.data.reply };
       setMessages((prev) => [...prev, botMessage]);
     } catch (err) {


### PR DESCRIPTION
## Summary
- expand `/api/sodabot` backend endpoint to include user-based lookup and OpenAI insight generation
- update chat component to send the wallet address when talking to SodaBot

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix backend test` *(fails: missing script)*
- `npm --prefix backend run build`

------
https://chatgpt.com/codex/tasks/task_e_6853480c8424832797c555851a7776ed