### PR TITLE
Fix image upload auth token usage

### DIFF
--- a/frontend/src/pages/CreateItemForm.tsx
+++ b/frontend/src/pages/CreateItemForm.tsx
@@ -23,7 +23,8 @@ import {
 } from "@chakra-ui/react";
 import { useState, useRef } from "react";
 import axios from "../utils/axiosConfig";
-import { uploadToNftStorageV2 } from "../utils/nftStorage";
+import { uploadImage } from "../utils/uploadImage";
+import { getToken } from "../utils/authToken";
 
 export default function CreateItemForm() {
   const [form, setForm] = useState({
@@ -72,8 +73,9 @@ export default function CreateItemForm() {
   const uploadFile = async (file: File) => {
     setImageFile(file);
     try {
-      const cid = await uploadToNftStorageV2(file);
-      setIpfsUrl(`https://ipfs.io/ipfs/${cid}`);
+      const token = getToken() || "";
+      const imageUrl = await uploadImage(file, token);
+      setIpfsUrl(imageUrl);
     } catch (err) {
       console.error("Image upload error:", err);
       toast({ title: "Failed to upload image", status: "error" });

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+export const uploadImage = async (file: File, token: string) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await axios.post("/api/upload", formData, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- add `uploadImage` utility that adds a Bearer auth header
- use new helper in `CreateItemForm` when uploading images

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685579523df08327907d49731bb9b10a