### PR TITLE
Fix upload route 404

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   base: '/',
   server: {
     open: false,
+    proxy: {
+      '/api': 'http://localhost:4000',
+    },
   },
   build: {
     assetsInlineLimit: 0,


### PR DESCRIPTION
## Summary
- forward `/api` requests from Vite dev server to backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557c7acf848327a9098e11bc244d72