### PR TITLE
Log token and adjust upload route

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -42,6 +42,7 @@ app.get("/api/hello", (_req: Request, res: Response) => {
 
 function requireAuth(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers.authorization;
+  console.log("Auth header received:", authHeader);
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
     res.status(401).json({ error: "Unauthorized" });
     return;
@@ -57,6 +58,9 @@ function requireAuth(req: Request, res: Response, next: NextFunction) {
 
 // Mount auth routes (unprotected)
 app.use("/api/auth", authRoutes);
+
+// File upload endpoint (unprotected)
+app.use("/api/upload", uploadRoutes);
 
 // Mount portfolio routes (protected)
 app.use("/api", requireAuth, portfolioRoutes);
@@ -78,9 +82,6 @@ app.use("/api/leaderboard", leaderboardRoutes);
 
 // SodaBot chat endpoint (unprotected)
 app.use("/api/sodabot", sodabotRoutes);
-
-// File upload endpoint (unprotected)
-app.use("/api/upload", uploadRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Backend listening on http://localhost:${PORT}`);

--- a/frontend/src/utils/authToken.ts
+++ b/frontend/src/utils/authToken.ts
@@ -6,7 +6,9 @@ export function setToken(token: string) {
 }
 
 export function getToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+  const token = localStorage.getItem(TOKEN_KEY);
+  console.log("Token from getToken():", token);
+  return token;
 }
 
 export function clearToken() {

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -4,6 +4,8 @@ export const uploadImage = async (file: File, token: string) => {
   const formData = new FormData();
   formData.append("file", file);
 
+  console.log("Sending upload request with token:", token);
+
   const response = await axios.post("/api/upload", formData, {
     headers: {
       Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- log token in `getToken()` and in `uploadImage`
- log received authorization header in server middleware
- move `/api/upload` route before auth middleware

## Testing
- `npm --prefix frontend test` *(fails: vitest not found)*
- `npm --prefix backend test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68557e43127083279c45ce28089a26a2