### PR TITLE
Handle wallet install error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import {
   HStack,
   Button,
   Text,
+  useToast,
 } from "@chakra-ui/react";
 import { useAccount, useConnect, useDisconnect } from "wagmi";
 import { clearToken } from "./utils/authToken";
@@ -31,6 +32,7 @@ const App: React.FC = () => {
   const { connect, connectors, isLoading: connectLoading } = useConnect();
   const { disconnect } = useDisconnect();
   const navigate = useNavigate();
+  const toast = useToast();
 
   const handleLogout = () => {
     clearToken();
@@ -99,7 +101,17 @@ const App: React.FC = () => {
               connectors.map((connector) => (
                 <Button
                   key={connector.id}
-                  onClick={() => connect({ connector })}
+                  onClick={() => {
+                    connect({ connector }).catch((err) => {
+                      if ((err as Error).name === "ConnectorNotFoundError") {
+                        toast({
+                          title:
+                            "Add a web 3 wallet from your browser's marketplace",
+                          status: "error",
+                        });
+                      }
+                    });
+                  }}
                   isLoading={
                     connectLoading && connector.id === connectors?.[0]?.id
                   }


### PR DESCRIPTION
## Summary
- ensure Chakra toast is available in App
- show error toast prompting user to install a web3 wallet when wallet connection fails

## Testing
- `npm test` *(fails: Jest not found)*
- `npx --yes vitest run --dir frontend`

------
https://chatgpt.com/codex/tasks/task_e_685a064538848327a630d4f87ac1607b