### PR TITLE
Refactor frontend HTTP client to support configurable API base

### DIFF
--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { VStack, HStack, Box, Input, Button, Text } from "@chakra-ui/react";
-import axios from "axios";
+import axios from "../utils/axiosConfig";
 
 type ChatMessage = {
   role: "system" | "user" | "assistant";
@@ -33,7 +33,7 @@ const ChatWindow: React.FC = () => {
     setIsSending(true);
 
     try {
-      const response = await axios.post("/api/chat/message", {
+      const response = await axios.post("/chat/message", {
         message: userMsg,
       });
 

--- a/frontend/src/components/ItemViewer.tsx
+++ b/frontend/src/components/ItemViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { SAMPLE_METADATA_URL } from "../utils/config";
 
 interface Attribute {
   trait_type: string;
@@ -16,9 +17,14 @@ const ItemViewer: React.FC = () => {
   const [item, setItem] = useState<ItemMetadata | null>(null);
 
   useEffect(() => {
+    if (!SAMPLE_METADATA_URL) {
+      console.warn("SAMPLE_METADATA_URL is not configured; skipping metadata fetch.");
+      return;
+    }
+
     const fetchMetadata = async () => {
       try {
-        const res = await fetch("http://127.0.0.1:8080/1.json");
+        const res = await fetch(SAMPLE_METADATA_URL);
         const ct = res.headers.get("content-type") || "";
         if (!ct.includes("application/json")) {
           const text = await res.text();

--- a/frontend/src/components/SodaBot.tsx
+++ b/frontend/src/components/SodaBot.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import axios from "axios";
+import axios from "../utils/axiosConfig";
 import { useAccount } from "wagmi";
 
 const SodaBot = () => {
@@ -15,7 +15,7 @@ const SodaBot = () => {
     setInput("");
 
     try {
-      const res = await axios.post("/api/sodabot", {
+      const res = await axios.post("/sodabot", {
         prompt: input,
         userAddress: address?.toLowerCase(),
       });

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -30,7 +30,7 @@ const Login: React.FC = () => {
     }
     setLoading(true);
     try {
-      const resp = await axios.post("http://localhost:4000/api/auth/login", {
+      const resp = await axios.post("/auth/login", {
         username,
         password,
       });

--- a/frontend/src/components/auth/Register.tsx
+++ b/frontend/src/components/auth/Register.tsx
@@ -27,7 +27,7 @@ const Register: React.FC = () => {
     }
     setLoading(true);
     try {
-      await axios.post("http://localhost:4000/api/auth/register", {
+      await axios.post("/auth/register", {
         username,
         password,
       });

--- a/frontend/src/pages/ItemDetail.tsx
+++ b/frontend/src/pages/ItemDetail.tsx
@@ -31,7 +31,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { ethers } from "ethers";
-import axios from "axios";
+import axios from "../utils/axiosConfig";
 import {
   useAccount,
   usePrepareContractWrite,
@@ -190,7 +190,7 @@ const ItemDetail: React.FC = () => {
     if (!id) return;
     const fetchMarket = async () => {
       try {
-        const res = await axios.get(`/api/asset/market-data/${id}`);
+        const res = await axios.get(`/asset/market-data/${id}`);
         const data = res.data as { price: number; timestamp: string };
         setMarketData((prev) => [...prev.slice(-19), data]);
         setLatestPrice(data.price);

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,11 +1,7 @@
-import axios from "axios";
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_BACKEND_URL || "http://localhost:5000/api",
-});
+import axios from "./axiosConfig";
 
 // TEMP: Mock response for /items/:id
-api.interceptors.response.use((response) => {
+axios.interceptors.response.use((response) => {
   if (
     response.config.url?.match(/\/items\/\w+/) &&
     response.config.method === "get"
@@ -28,4 +24,4 @@ api.interceptors.response.use((response) => {
   return response;
 });
 
-export default api;
+export default axios;

--- a/frontend/src/utils/axiosConfig.ts
+++ b/frontend/src/utils/axiosConfig.ts
@@ -1,12 +1,14 @@
 import axios from "axios";
+import { API_BASE_URL } from "./config";
 
 const instance = axios.create({
-  baseURL: "http://localhost:4000/api",
+  baseURL: API_BASE_URL,
 });
 
 instance.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
   if (token) {
+    config.headers = config.headers ?? {};
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -1,0 +1,16 @@
+export const API_BASE_URL = (() => {
+  const raw = import.meta.env.VITE_BACKEND_URL?.trim();
+  if (!raw) {
+    return "/api";
+  }
+
+  const normalized = raw.replace(/\/+$/, "");
+  if (normalized.toLowerCase().endsWith("/api")) {
+    return normalized;
+  }
+
+  return `${normalized}/api`;
+})();
+
+export const SAMPLE_METADATA_URL =
+  import.meta.env.VITE_SAMPLE_METADATA_URL?.trim() || "";

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "./axiosConfig";
 
 export const uploadImage = async (file: File, token: string) => {
   const formData = new FormData();
@@ -6,7 +6,7 @@ export const uploadImage = async (file: File, token: string) => {
 
   console.log("Sending upload request with token:", token);
 
-  const response = await axios.post("/api/upload", formData, {
+  const response = await axios.post("/upload", formData, {
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "multipart/form-data",


### PR DESCRIPTION
## Summary
- add a shared configuration helper that resolves the deployment API base URL from environment variables
- update the Axios client and all frontend consumers to rely on the shared base instead of hard-coded localhost URLs
- allow the item metadata viewer to use a configurable sample metadata URL rather than a fixed 127.0.0.1 endpoint

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d3416d16088327be46d1a829b9b82b