### PR TITLE
Mark fsevents optional for Linux installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6963,6 +6963,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "extraneous": true,
+      "optional": true,
       "os": [
         "darwin"
       ],


### PR DESCRIPTION
## Summary
- mark the ganache-managed fsevents dependency as optional in the root lockfile so npm can skip it on non-macOS platforms

## Testing
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68d353478cc88327bd6c072ef12544cc