### PR TITLE
Fix image upload auth token handling

### DIFF
--- a/frontend/src/pages/CreateItemForm.tsx
+++ b/frontend/src/pages/CreateItemForm.tsx
@@ -28,7 +28,6 @@ import {
 import { useState, useRef } from "react";
 import axios from "../utils/axiosConfig";
 import { uploadImage } from "../utils/uploadImage";
-import { getToken } from "../utils/authToken";
 
 export default function CreateItemForm() {
   const [form, setForm] = useState({
@@ -77,8 +76,7 @@ export default function CreateItemForm() {
   const uploadFile = async (file: File) => {
     setImageFile(file);
     try {
-      const token = getToken() || "";
-      const imageUrl = await uploadImage(file, token);
+      const imageUrl = await uploadImage(file);
       setIpfsUrl(imageUrl);
     } catch (err) {
       console.error("Image upload error:", err);

--- a/frontend/src/utils/authToken.ts
+++ b/frontend/src/utils/authToken.ts
@@ -1,5 +1,5 @@
 // File: frontend/src/utils/authToken.ts
-const TOKEN_KEY = "sodapop_jwt";
+export const TOKEN_KEY = "sodapop_jwt";
 
 export function setToken(token: string) {
   localStorage.setItem(TOKEN_KEY, token);

--- a/frontend/src/utils/axiosConfig.ts
+++ b/frontend/src/utils/axiosConfig.ts
@@ -1,12 +1,13 @@
 import axios from "axios";
 import { API_BASE_URL } from "./config";
+import { getToken } from "./authToken";
 
 const instance = axios.create({
   baseURL: API_BASE_URL,
 });
 
 instance.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
+  const token = getToken();
   if (token) {
     config.headers = config.headers ?? {};
     config.headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -1,16 +1,23 @@
 import axios from "./axiosConfig";
+import { getToken } from "./authToken";
 
-export const uploadImage = async (file: File, token: string) => {
+export const uploadImage = async (file: File) => {
   const formData = new FormData();
   formData.append("file", file);
 
+  const token = getToken();
   console.log("Sending upload request with token:", token);
 
+  const headers: Record<string, string> = {
+    "Content-Type": "multipart/form-data",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
   const response = await axios.post("/upload", formData, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "multipart/form-data",
-    },
+    headers,
   });
 
   return response.data;


### PR DESCRIPTION
## Summary
- export the shared auth token key so axios requests reuse the same storage entry
- have the upload helper fetch the token itself and only send an auth header when available
- simplify the create item form to rely on the updated helper when sending image uploads

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d37384f61483278895f2704ee5672d