### PR TITLE
Fix upload request path to respect configured API base URL

### DIFF
--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -16,7 +16,7 @@ export const uploadImage = async (file: File) => {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const response = await axios.post("/upload", formData, {
+  const response = await axios.post("upload", formData, {
     headers,
   });
 


### PR DESCRIPTION
## Summary
- update the uploadImage helper to call the relative "upload" endpoint so axios keeps the configured API base prefix

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d376026bb883279616e199e26ece39