### PR TITLE
Fix Vitest import in Jest test suite

### DIFF
--- a/frontend/src/utils/formatAddress.test.ts
+++ b/frontend/src/utils/formatAddress.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { formatAddress } from './formatAddress';
 
 describe('formatAddress', () => {


### PR DESCRIPTION
## Summary
- remove the Vitest import from the formatAddress test so it runs under Jest

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d37806a5f88327a4672bfee7a1b9ed