### PR TITLE
Ensure API base URL retains trailing slash

### DIFF
--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -1,15 +1,15 @@
 export const API_BASE_URL = (() => {
   const raw = import.meta.env.VITE_BACKEND_URL?.trim();
   if (!raw) {
-    return "/api";
+    return "/api/";
   }
 
   const normalized = raw.replace(/\/+$/, "");
-  if (normalized.toLowerCase().endsWith("/api")) {
-    return normalized;
-  }
+  const base = normalized.toLowerCase().endsWith("/api")
+    ? normalized
+    : `${normalized}/api`;
 
-  return `${normalized}/api`;
+  return base.endsWith("/") ? base : `${base}/`;
 })();
 
 export const SAMPLE_METADATA_URL =


### PR DESCRIPTION
## Summary
- ensure the computed API base URL always includes a trailing slash so relative requests keep the `/api` prefix

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d378cee7448327937dd12a5074dd44