### PR TITLE
Refine image upload flow for create item form

### DIFF
--- a/frontend/src/pages/CreateItemForm.tsx
+++ b/frontend/src/pages/CreateItemForm.tsx
@@ -38,8 +38,8 @@ export default function CreateItemForm() {
     shareType: "Fixed",
   });
 
-  const [imageFile, setImageFile] = useState<File | null>(null);
   const [ipfsUrl, setIpfsUrl] = useState<string | null>(null);
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
   const [dragging, setDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -74,13 +74,19 @@ export default function CreateItemForm() {
   };
 
   const uploadFile = async (file: File) => {
-    setImageFile(file);
     try {
-      const imageUrl = await uploadImage(file);
-      setIpfsUrl(imageUrl);
+      const { ipfsUri, previewUrl } = await uploadImage(file);
+      setIpfsUrl(ipfsUri);
+      setImagePreviewUrl(previewUrl);
     } catch (err) {
       console.error("Image upload error:", err);
-      toast({ title: "Failed to upload image", status: "error" });
+      setIpfsUrl(null);
+      setImagePreviewUrl(null);
+      const description =
+        err instanceof Error
+          ? err.message
+          : "We couldn't upload your image. Please try again.";
+      toast({ title: "Failed to upload image", description, status: "error" });
     }
   };
 
@@ -272,8 +278,14 @@ export default function CreateItemForm() {
               borderRadius="xl"
               transition="border-color 0.2s ease"
             >
-              {ipfsUrl ? (
-                <Image src={ipfsUrl} alt="preview" maxH="200px" mx="auto" borderRadius="lg" />
+              {imagePreviewUrl ? (
+                <Image
+                  src={imagePreviewUrl}
+                  alt="preview"
+                  maxH="200px"
+                  mx="auto"
+                  borderRadius="lg"
+                />
               ) : (
                 <Text color="whiteAlpha.600">Drag & drop or click to upload</Text>
               )}
@@ -292,7 +304,7 @@ export default function CreateItemForm() {
         </SimpleGrid>
 
         <Divider my={8} borderColor="rgba(148, 163, 255, 0.25)" />
-        {ipfsUrl && (
+        {imagePreviewUrl && (
           <Box
             mt={4}
             p={6}
@@ -305,7 +317,7 @@ export default function CreateItemForm() {
               Vision preview
             </Heading>
             <Stack direction={{ base: "column", md: "row" }} spacing={6} align="center">
-              <Image src={ipfsUrl} alt="Preview" maxH="180px" borderRadius="xl" />
+              <Image src={imagePreviewUrl} alt="Preview" maxH="180px" borderRadius="xl" />
               <VStack align="stretch" spacing={2} color="whiteAlpha.700">
                 <Text>
                   <strong>Type:</strong> {form.itemType}

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -1,24 +1,79 @@
 import axios from "./axiosConfig";
 import { getToken } from "./authToken";
+import { uploadToNftStorageV2 } from "./nftStorage";
 
-export const uploadImage = async (file: File) => {
-  const formData = new FormData();
-  formData.append("file", file);
+const NFT_STORAGE_GATEWAY = "https://nftstorage.link/ipfs/";
 
-  const token = getToken();
-  console.log("Sending upload request with token:", token);
+export interface UploadImageResult {
+  /**
+   * Canonical IPFS URI returned by NFT.Storage (e.g. ipfs://<cid>)
+   * that should be persisted in on-chain metadata.
+   */
+  ipfsUri: string;
+  /**
+   * HTTP URL that can be rendered directly in the browser for previews.
+   */
+  previewUrl: string;
+}
 
-  const headers: Record<string, string> = {
-    "Content-Type": "multipart/form-data",
-  };
-
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+/**
+ * Uploads an asset to NFT.Storage and returns a preview + canonical URI.
+ * Falls back to the legacy backend endpoint if the decentralized upload fails
+ * so that existing environments without NFT.Storage credentials still work.
+ */
+export const uploadImage = async (file: File): Promise<UploadImageResult> => {
+  if (!(file instanceof File)) {
+    throw new Error("A valid file must be provided for upload.");
   }
 
-  const response = await axios.post("upload", formData, {
-    headers,
-  });
+  try {
+    const cid = await uploadToNftStorageV2(file);
+    const trimmedCid = cid.trim();
+    if (!trimmedCid) {
+      throw new Error("NFT.Storage returned an empty CID.");
+    }
 
-  return response.data;
+    return {
+      ipfsUri: `ipfs://${trimmedCid}`,
+      previewUrl: `${NFT_STORAGE_GATEWAY}${trimmedCid}`,
+    };
+  } catch (primaryError) {
+    console.warn("NFT.Storage upload failed, falling back to legacy uploader.", primaryError);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const token = getToken();
+    const headers: Record<string, string> = {};
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    try {
+      const response = await axios.post("upload", formData, { headers });
+      const data = response.data ?? {};
+      const candidateUrl =
+        typeof data === "string"
+          ? data
+          : data.url ?? data.imageUrl ?? data.previewUrl ?? data.location ?? null;
+
+      if (typeof candidateUrl !== "string" || !candidateUrl.trim()) {
+        throw new Error("Upload API did not return an accessible image URL.");
+      }
+
+      const finalUrl = candidateUrl.trim();
+      return {
+        ipfsUri: finalUrl,
+        previewUrl: finalUrl,
+      };
+    } catch (fallbackError) {
+      const reason =
+        fallbackError instanceof Error
+          ? fallbackError.message
+          : typeof fallbackError === "string"
+            ? fallbackError
+            : "Unknown error";
+      throw new Error(`Image upload failed: ${reason}`);
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- switch the shared upload helper to push images to NFT.Storage first and fall back to the legacy API only if needed
- have the helper return both an ipfs:// URI and a browser preview URL for downstream consumers
- update the create item form to consume the richer upload response, show the preview correctly, and surface clearer error messaging when uploads fail

## Testing
- npm --prefix frontend run build *(fails: TypeScript build pulls in Jest tests without globals)*

------
https://chatgpt.com/codex/tasks/task_e_68d37ad026d8832782270b54e7d5fd8b