### PR TITLE
Fix legacy upload endpoint to return accessible file URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 backend/.env
 frontend/node_modules/
 backend/dist/
+backend/uploads/

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import cors from "cors";
 import dotenv from "dotenv";
 import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
+import fs from "fs";
+import path from "path";
 
 import authRoutes from "./controllers/auth";
 import portfolioRoutes from "./controllers/portfolio";
@@ -28,8 +30,15 @@ if (MONGO_URI) {
 }
 
 const app = express();
+app.set("trust proxy", true);
 app.use(cors());
 app.use(express.json());
+
+const uploadsDir = path.resolve(process.cwd(), "uploads");
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir, { recursive: true });
+}
+app.use("/uploads", express.static(uploadsDir));
 
 // Health check
 app.get("/healthz", (_req: Request, res: Response) => {

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -1,9 +1,36 @@
 import express, { Request, Response } from "express";
 import multer from "multer";
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
 
 const router = express.Router();
 
-const storage = multer.memoryStorage();
+const UPLOADS_DIR = path.resolve(process.cwd(), "uploads");
+
+function ensureUploadsDirExists(): void {
+  if (!fs.existsSync(UPLOADS_DIR)) {
+    fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+  }
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    try {
+      ensureUploadsDirExists();
+      cb(null, UPLOADS_DIR);
+    } catch (err) {
+      cb(err as Error, UPLOADS_DIR);
+    }
+  },
+  filename: (_req, file, cb) => {
+    const extension = path.extname(file.originalname) || "";
+    const randomName = crypto.randomBytes(16).toString("hex");
+    const filename = `${Date.now()}-${randomName}${extension}`;
+    cb(null, filename);
+  },
+});
+
 const upload = multer({ storage });
 
 router.post("/", upload.single("file"), (req: Request, res: Response): void => {
@@ -14,10 +41,20 @@ router.post("/", upload.single("file"), (req: Request, res: Response): void => {
       return;
     }
 
+    const forwardedProto = req.get("x-forwarded-proto");
+    const forwardedHost = req.get("x-forwarded-host");
+    const protocol = forwardedProto?.split(",")[0]?.trim() || req.protocol;
+    const host = forwardedHost ?? req.get("host");
+    const publicPath = `/uploads/${file.filename}`;
+    const absoluteUrl = host ? `${protocol}://${host}${publicPath}` : publicPath;
+
     res.json({
       filename: file.originalname,
       mimetype: file.mimetype,
       size: file.size,
+      url: absoluteUrl,
+      previewUrl: absoluteUrl,
+      path: publicPath,
     });
   } catch (err) {
     console.error("Upload failed:", err);


### PR DESCRIPTION
## Summary
- persist uploaded files to disk with deterministic storage paths and stable filenames
- expose the uploads directory via Express so fallback uploads return usable preview URLs
- include absolute URLs in the upload response for compatibility with the frontend fallback logic

## Testing
- npm run build (backend)


------
https://chatgpt.com/codex/tasks/task_e_68d37ee925188327bf482c03b222cc5d