### PR TITLE
Improve upload logging and fallbacks

### DIFF
--- a/frontend/src/utils/nftStorage.ts
+++ b/frontend/src/utils/nftStorage.ts
@@ -1,28 +1,53 @@
-import axios from 'axios';
+import axios from "axios";
 
-export async function uploadToNftStorageV2(file: File) {
-  const API_KEY = import.meta.env.VITE_NFT_STORAGE_KEY;
+const NFT_STORAGE_UPLOAD_URL = "https://api.nft.storage/upload";
+
+export async function uploadToNftStorageV2(file: File): Promise<string> {
+  const rawApiKey = import.meta.env.VITE_NFT_STORAGE_KEY;
+  const apiKey = typeof rawApiKey === "string" ? rawApiKey.trim() : "";
+
+  if (!apiKey) {
+    const error = new Error("NFT.Storage API key is not configured");
+    (error as Error & { code?: string }).code = "MISSING_NFT_STORAGE_KEY";
+    console.warn("[nftStorage] NFT.Storage API key missing; skipping decentralized upload", {
+      name: file.name,
+    });
+    throw error;
+  }
 
   const formData = new FormData();
-  formData.append('file', file);
+  formData.append("file", file);
 
   try {
-    const response = await axios.post('https://api.nft.storage/upload', formData, {
+    const response = await axios.post(NFT_STORAGE_UPLOAD_URL, formData, {
       headers: {
-        Authorization: `Bearer ${API_KEY}`,
-        'Content-Type': 'multipart/form-data',
+        Authorization: `Bearer ${apiKey}`,
       },
     });
 
-    if (response.data.ok) {
-      const cid = response.data.value.cid;
-      console.log(`✅ Uploaded to IPFS with CID: ${cid}`);
+    if (response.data?.ok) {
+      const cid = String(response.data.value?.cid ?? "").trim();
+      if (!cid) {
+        throw new Error("NFT.Storage response did not include a CID");
+      }
+
+      console.info("[nftStorage] Uploaded asset to IPFS", {
+        name: file.name,
+        cid,
+      });
+
       return cid;
-    } else {
-      throw new Error(`❌ Upload failed: ${JSON.stringify(response.data.error)}`);
     }
+
+    throw new Error(
+      `NFT.Storage request failed: ${JSON.stringify(response.data?.error ?? response.data)}`,
+    );
   } catch (err) {
-    console.error('❌ Upload error:', err);
+    console.error("[nftStorage] Upload request failed", {
+      name: file.name,
+      message: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- add structured logging and explicit error handling to the upload API so request failures are easier to triage
- harden the NFT.Storage helper to skip when no API key is configured and surface richer diagnostics
- expand the frontend upload helper logging, including axios error details, when the legacy uploader is used

## Testing
- npm --prefix backend run build
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d382038c9883279b7e0eb7ecec1b0d