### PR TITLE
Align token record payload with backend schema

### DIFF
--- a/backend/dist/utils/config.js
+++ b/backend/dist/utils/config.js
@@ -7,7 +7,7 @@ exports.MONGO_URI = exports.ALERT_EMAIL = exports.SMTP_PASS = exports.SMTP_USER 
 const dotenv_1 = __importDefault(require("dotenv"));
 dotenv_1.default.config();
 const getString = (value, fallback = "") => (value ?? "").trim() || fallback;
-exports.PORT = Number(process.env.PORT) || 8080;
+exports.PORT = Number(process.env.PORT) || 4000;
 exports.OPENAI_API_KEY = getString(process.env.OPENAI_API_KEY);
 exports.SOLANA_RPC_URL = getString(process.env.SOLANA_RPC_URL, "https://api.devnet.solana.com");
 exports.JWT_SECRET = getString(process.env.JWT_SECRET, "replace_with_strong_secret");

--- a/backend/src/utils/config.ts
+++ b/backend/src/utils/config.ts
@@ -5,7 +5,7 @@ dotenv.config();
 const getString = (value?: string | null, fallback = "") =>
   (value ?? "").trim() || fallback;
 
-export const PORT = Number(process.env.PORT) || 8080;
+export const PORT = Number(process.env.PORT) || 4000;
 export const OPENAI_API_KEY = getString(process.env.OPENAI_API_KEY);
 export const SOLANA_RPC_URL = getString(
   process.env.SOLANA_RPC_URL,

--- a/frontend/src/lib/recordToken.ts
+++ b/frontend/src/lib/recordToken.ts
@@ -1,16 +1,48 @@
 const API = import.meta.env.VITE_API_BASE_URL ?? "/api";
 
-export async function recordToken(params: {
-  network: string;
-  owner?: string;
+export interface RecordTokenPayload {
   mint: string;
-  signature: string;
-  metadata?: any;
-}) {
+  tx: string;
+  name: string;
+  symbol: string;
+  creatorWallet: string;
+  ata: string;
+  amount?: string | number | bigint;
+  decimals?: number;
+  imageUrl?: string;
+}
+
+export async function recordToken(params: RecordTokenPayload) {
+  const payload: Record<string, unknown> = {
+    mint: params.mint,
+    tx: params.tx,
+    name: params.name,
+    symbol: params.symbol,
+    creatorWallet: params.creatorWallet,
+    ata: params.ata,
+  };
+
+  if (params.imageUrl) {
+    payload.imageUrl = params.imageUrl;
+  }
+
+  if (params.decimals !== undefined) {
+    payload.decimals = params.decimals;
+  }
+
+  if (params.amount !== undefined) {
+    payload.amount =
+      typeof params.amount === "bigint"
+        ? params.amount.toString(10)
+        : typeof params.amount === "number"
+          ? params.amount.toString(10)
+          : params.amount;
+  }
+
   const r = await fetch(`${API}/tokens/record`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify(params),
+    body: JSON.stringify(payload),
   });
 
   // don't blindly call res.json(); 405/500 often returns empty text/html


### PR DESCRIPTION
## Summary
- update the frontend recordToken helper to match the backend /api/tokens/record schema
- send the correct payload from CreateItemForm and reuse it when retrying a failed save
- default the backend port to 4000 so the Vite proxy can reach the API

## Testing
- npm run build (frontend)
- npm run build (backend)

------
https://chatgpt.com/codex/tasks/task_e_68d4930a2f3c8327b27368e224965d5b