### PR TITLE
Fix Vite alias for recordToken

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary
- add Vite resolve alias for the `@/` prefix to point at `frontend/src`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49c9259688327ba033dc95a0e320d