### PR TITLE
Fix npm build by rebuilding esbuild and repairing Vite config

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   server: {
     proxy: {
       "/api": { target: "http://localhost:8080", changeOrigin: true },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "workspaces": ["frontend", "server"],
   "scripts": {
-    "build": "npm --prefix frontend run build && npm --prefix server run build",
+    "build": "npm --prefix frontend rebuild esbuild && npm --prefix frontend run build && npm --prefix server run build",
     "start": "npm --prefix server run start"
   }
 }


### PR DESCRIPTION
## Summary
- ensure the build script rebuilds the frontend esbuild binary before compiling to avoid version mismatches
- restore a valid Vite configuration with an explicit `@` alias and API proxy definition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b0b8f60483278f0ffd89a976db6b