### PR TITLE
fix: align esbuild version with runtime

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.0.0",
+    "esbuild": "^0.25.10",
     "typescript": "^5.8.3",
     "vite": "^4.0.0",
     "vitest": "^1.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.0.0",
+        "esbuild": "^0.25.10",
         "typescript": "^5.8.3",
         "vite": "^4.0.0",
         "vitest": "^1.5.0"


### PR DESCRIPTION
## Summary
- add esbuild as a dev dependency of the frontend workspace to match Node 22 builds
- update the workspace lockfile so esbuild 0.25.10 is installed during deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b2fc0ee48327b505f5890af9a413