### PR TITLE
Remove esbuild overrides to fix build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,9 +39,6 @@
     "vite": "^4.0.0",
     "vitest": "^1.5.0"
   },
-  "overrides": {
-    "esbuild": "0.25.10"
-  },
   "description": "",
   "main": "index.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
   "scripts": {
     "build": "npm --prefix frontend rebuild esbuild && npm --prefix frontend run build && npm --prefix server run build",
     "start": "npm --prefix server run start"
-  },
-  "overrides": {
-    "esbuild": "0.25.10"
   }
 }


### PR DESCRIPTION
## Summary
- remove the esbuild override from the workspace root and frontend package so dependencies can manage their compatible versions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bf215c648327a78f94e8cca177c5