### PR TITLE
Add SodaPop spot market UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,11 +24,13 @@
         "axios": "^1.9.0",
         "buffer": "^6.0.3",
         "framer-motion": "^12.15.0",
+        "lightweight-charts": "^5.0.8",
         "process": "^0.11.10",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^7.6.1",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@types/react": "^19.1.8",
@@ -12539,6 +12541,12 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14115,6 +14123,15 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lightweight-charts": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-5.0.8.tgz",
+      "integrity": "sha512-dNBK5TlNcG78RUnxYRAZP4XpY5bkp3EE0PPjFFPkdIZ8RvnvL2JLgTb1BLh40trHhgJl51b1bCz8678GpnKvIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -19524,6 +19541,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,11 +25,13 @@
     "axios": "^1.9.0",
     "buffer": "^6.0.3",
     "framer-motion": "^12.15.0",
+    "lightweight-charts": "^5.0.8",
     "process": "^0.11.10",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^7.6.1",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/frontend/src/features/sodaspot/CandleChart.tsx
+++ b/frontend/src/features/sodaspot/CandleChart.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from "react";
+import { createChart, IChartApi, UTCTimestamp, CandlestickSeries } from "lightweight-charts";
+import { useSoda, refresh } from "./store";
+
+export default function CandleChart() {
+  const ref = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+
+  useEffect(() => {
+    if (!ref.current || chartRef.current) return;
+    const chart = createChart(ref.current, { height: 380, rightPriceScale: { visible: true }, timeScale: { timeVisible: true }});
+    const series = chart.addSeries(CandlestickSeries);
+    chartRef.current = chart;
+    const draw = () => {
+      const data = useSoda.getState().candles.slice().reverse().map(c => ({
+        time: (c.t/1000) as UTCTimestamp, open: c.o, high: c.h, low: c.l, close: c.c
+      }));
+      series.setData(data);
+    };
+    draw();
+    const unsub = useSoda.subscribe((state, prev) => {
+      if (state.candles !== prev.candles) draw();
+    });
+    const ro = new ResizeObserver(() => chart.applyOptions({ width: ref.current!.clientWidth }));
+    ro.observe(ref.current);
+    const iv = setInterval(refresh, 1000);
+    return () => { clearInterval(iv); unsub(); ro.disconnect(); chart.remove(); };
+  }, []);
+
+  return <div className="w-full h-[380px]" ref={ref} />;
+}

--- a/frontend/src/features/sodaspot/Metrics.tsx
+++ b/frontend/src/features/sodaspot/Metrics.tsx
@@ -1,0 +1,14 @@
+import { useSoda } from "./store";
+export default function Metrics() {
+  const { last, vwap, twap, vol, book } = useSoda(s => ({ last: s.last, vwap: s.vwap, twap: s.twap, vol: s.vol, book: s.book }));
+  const mid = book?.bestBid && book?.bestAsk ? (book.bestBid + book.bestAsk)/2 : undefined;
+  return (
+    <div className="grid grid-cols-2 gap-4 p-3 text-sm">
+      <div>Current (Last): <span className="font-semibold">{last?.toFixed(6) ?? "—"} SOL</span></div>
+      <div>Mid / Spread: <span className="font-semibold">{mid?.toFixed(6) ?? "—"}</span> / {book?.bestAsk && book?.bestBid ? (book.bestAsk-book.bestBid).toFixed(6) : "—"}</div>
+      <div>VWAP (24h): <span className="font-semibold">{vwap?.toFixed(6) ?? "—"}</span></div>
+      <div>TWAP (5m): <span className="font-semibold">{twap?.toFixed(6) ?? "—"}</span></div>
+      <div>Realized Vol (ann.): <span className="font-semibold">{vol ? (vol*100).toFixed(2)+"%" : "—"}</span></div>
+    </div>
+  );
+}

--- a/frontend/src/features/sodaspot/OrderBook.tsx
+++ b/frontend/src/features/sodaspot/OrderBook.tsx
@@ -1,0 +1,28 @@
+import { useSoda } from "./store";
+function Row({ p, s, side }: { p: number; s: number; side: "bid"|"ask" }) {
+  return (
+    <div className="grid grid-cols-3 text-sm py-0.5">
+      <div className={side === "bid" ? "text-emerald-400" : "text-rose-400"}>{p.toFixed(6)}</div>
+      <div>{s.toFixed(4)}</div>
+      <div className="text-zinc-400">{(p*s).toFixed(4)} SOL</div>
+    </div>
+  );
+}
+export default function OrderBook() {
+  const book = useSoda(s => s.book);
+  if (!book) return <div className="p-3 text-zinc-400">Loading book…</div>;
+  const spread = book.bestAsk && book.bestBid ? (book.bestAsk - book.bestBid) : 0;
+  return (
+    <div className="p-3">
+      <div className="flex justify-between text-xs text-zinc-400 mb-1">
+        <span>Order Book (SOL/share)</span>
+        <span>Spread: {spread.toFixed(6)}</span>
+      </div>
+      <div className="space-y-1">
+        {book.asks.map((l, i) => <Row key={"a"+i} p={l.price} s={l.size} side="ask" />)}
+        <div className="h-[1px] bg-zinc-800 my-1" />
+        {book.bids.map((l, i) => <Row key={"b"+i} p={l.price} s={l.size} side="bid" />)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sodaspot/SodaSpot.tsx
+++ b/frontend/src/features/sodaspot/SodaSpot.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { refresh, useSoda, makeEngine } from "./store";
+import CandleChart from "./CandleChart";
+import OrderBook from "./OrderBook";
+import Trades from "./Trades";
+import Ticket from "./Ticket";
+import Metrics from "./Metrics";
+
+type Props = {
+  totalShares?: number;
+  issuedShares?: number;
+  treasuryAskPrice?: number; // starting quote in SOL/share
+};
+
+export default function SodaSpot(props: Props) {
+  // Boot with item params if provided
+  useEffect(() => {
+    if (props.totalShares) {
+      useSoda.setState({
+        engine: makeEngine({
+          totalShares: props.totalShares ?? 10,
+          issuedShares: props.issuedShares ?? 0,
+          treasuryAskPrice: props.treasuryAskPrice ?? 0.25,
+        }),
+        trades: [], candles: [], book: undefined, last: undefined
+      });
+    }
+    refresh();
+    const iv = setInterval(refresh, 1500);
+    return () => clearInterval(iv);
+  }, [props.totalShares, props.issuedShares, props.treasuryAskPrice]);
+
+  const last = useSoda(s=>s.last);
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-9 space-y-4">
+        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800">
+          <div className="px-4 py-2 text-sm text-zinc-400">SodaPop Shares • {last?.toFixed(6) ?? "—"} SOL/share</div>
+          <CandleChart />
+        </div>
+        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800"><Trades /></div>
+      </div>
+      <div className="col-span-3 space-y-4">
+        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800"><Ticket /></div>
+        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800"><OrderBook /></div>
+        <div className="rounded-2xl bg-zinc-900/60 border border-zinc-800"><Metrics /></div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sodaspot/Ticket.tsx
+++ b/frontend/src/features/sodaspot/Ticket.tsx
@@ -1,0 +1,43 @@
+import { place, useSoda } from "./store";
+import { useState } from "react";
+export default function Ticket() {
+  const last = useSoda(s => s.last);
+  const [side, setSide] = useState<"buy"|"sell">("buy");
+  const [type, setType] = useState<"limit"|"market">("limit");
+  const [price, setPrice] = useState<number | "">(last ?? "");
+  const [size, setSize] = useState<number | "">("");
+
+  const submit = () => {
+    if (!size || (type==="limit" && !price)) return alert("Enter price/size");
+    place({ side, type, price: type==="limit" ? Number(price) : undefined, size: Number(size) });
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <div className="flex gap-2">
+        <button onClick={()=>setSide("buy")} className={`px-3 py-1 rounded ${side==="buy"?"bg-emerald-600 text-white":"bg-zinc-800"}`}>Acquire</button>
+        <button onClick={()=>setSide("sell")} className={`px-3 py-1 rounded ${side==="sell"?"bg-rose-600 text-white":"bg-zinc-800"}`}>Sell</button>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={()=>setType("limit")} className={`px-3 py-1 rounded ${type==="limit"?"bg-zinc-700":"bg-zinc-800"}`}>Limit</button>
+        <button onClick={()=>setType("market")} className={`px-3 py-1 rounded ${type==="market"?"bg-zinc-700":"bg-zinc-800"}`}>Market</button>
+      </div>
+      {type==="limit" && (
+        <div className="space-y-1">
+          <label className="text-xs text-zinc-400">Limit price (SOL/share)</label>
+          <input className="w-full bg-zinc-900 rounded px-2 py-1" value={price} onChange={e=>setPrice(e.target.value===""?"":Number(e.target.value))} />
+        </div>
+      )}
+      <div className="space-y-1">
+        <label className="text-xs text-zinc-400">Size (shares)</label>
+        <input className="w-full bg-zinc-900 rounded px-2 py-1" value={size} onChange={e=>setSize(e.target.value===""?"":Number(e.target.value))} />
+      </div>
+      <button onClick={submit} className={`w-full py-2 rounded ${side==="buy"?"bg-emerald-600":"bg-rose-600"} text-white`}>
+        {side==="buy"?"Acquire shares":"Sell shares"}
+      </button>
+      <div className="text-xs text-zinc-400">
+        Last: {last?.toFixed(6) ?? "—"} SOL/share
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sodaspot/Trades.tsx
+++ b/frontend/src/features/sodaspot/Trades.tsx
@@ -1,0 +1,18 @@
+import { useSoda } from "./store";
+export default function Trades() {
+  const trades = useSoda(s => s.trades);
+  return (
+    <div className="p-3">
+      <div className="flex justify-between text-xs text-zinc-400 mb-1"><span>Recent Trades</span></div>
+      <div className="space-y-1 max-h-[200px] overflow-auto pr-1">
+        {trades.map((t, i) => (
+          <div key={i} className="grid grid-cols-3 text-sm">
+            <div className={t.taker==="buy" ? "text-emerald-400" : "text-rose-400"}>{t.price.toFixed(6)}</div>
+            <div>{t.size.toFixed(4)} sh</div>
+            <div className="text-zinc-400">{new Date(t.ts).toLocaleTimeString()}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/sodaspot/engine.ts
+++ b/frontend/src/features/sodaspot/engine.ts
@@ -1,0 +1,133 @@
+// Lightweight central limit order book (CLOB) + analytics for SodaPop shares (SOL per share)
+export type Side = "buy" | "sell";
+export type OrderType = "limit" | "market";
+export type Order = { id: string; side: Side; type: OrderType; price?: number; size: number; ts: number };
+export type Trade = { price: number; size: number; taker: Side; ts: number };
+export type Level = { price: number; size: number };
+export type Book = { bids: Level[]; asks: Level[]; bestBid?: number; bestAsk?: number; ts: number };
+
+export type MarketConfig = {
+  totalShares: number;          // e.g., 10
+  issuedShares: number;         // e.g., 3
+  treasuryAskPrice: number;     // initial ref price in SOL/share (e.g., 0.25)
+  seedDepth?: number;           // how many price levels to seed
+};
+
+export class Engine {
+  private bids: Level[] = [];
+  private asks: Level[] = [];
+  private trades: Trade[] = [];
+  private lastPrice?: number;
+
+  constructor(public cfg: MarketConfig) {
+    this.seedBook();
+  }
+
+  private pushTrade(t: Trade) {
+    this.trades.unshift(t);
+    this.trades = this.trades.slice(0, 5000);
+    this.lastPrice = t.price;
+  }
+
+  getBook(): Book {
+    const bestBid = this.bids[0]?.price;
+    const bestAsk = this.asks[0]?.price;
+    return { bids: this.bids.slice(0, 20), asks: this.asks.slice(0, 20), bestBid, bestAsk, ts: Date.now() };
+  }
+
+  getTrades(): Trade[] { return this.trades.slice(0, 200); }
+  getLastPrice(): number | undefined { return this.lastPrice; }
+
+  place(o: Order): { filled: Trade[]; remaining?: Order } {
+    const filled: Trade[] = [];
+    const match = (book: Level[], takerSide: Side) => {
+      while (o.size > 0 && book.length) {
+        const level = book[0];
+        const x = Math.min(o.size, level.size);
+        level.size -= x;
+        if (level.size <= 1e-8) book.shift();
+        o.size -= x;
+        const price = level.price;
+        filled.push({ price, size: x, taker: takerSide, ts: Date.now() });
+        this.pushTrade(filled[filled.length - 1]);
+      }
+    };
+
+    if (o.type === "market") {
+      if (o.side === "buy") match(this.asks, "buy");
+      else match(this.bids, "sell");
+    } else {
+      // First, cross against opposite if marketable
+      if (o.side === "buy") {
+        while (o.size > 0 && this.asks.length && o.price! >= this.asks[0].price) {
+          match(this.asks, "buy");
+        }
+        if (o.size > 0) this.addLevel(this.bids, o.price!, o.size, "bid");
+      } else {
+        while (o.size > 0 && this.bids.length && o.price! <= this.bids[0].price) {
+          match(this.bids, "sell");
+        }
+        if (o.size > 0) this.addLevel(this.asks, o.price!, o.size, "ask");
+      }
+    }
+    return { filled, remaining: o.size > 0 ? o : undefined };
+  }
+
+  private addLevel(arr: Level[], price: number, size: number, side: "bid"|"ask") {
+    const idx = arr.findIndex(l => l.price === price);
+    if (idx >= 0) arr[idx].size += size;
+    else {
+      arr.push({ price, size });
+      arr.sort(side === "bid" ? (a,b)=> b.price - a.price : (a,b)=> a.price - b.price);
+    }
+  }
+
+  private seedBook() {
+    const L = this.cfg.seedDepth ?? 12;
+    const p0 = this.cfg.treasuryAskPrice;
+    // Treasury sells remaining shares on asks
+    const remaining = Math.max(this.cfg.totalShares - this.cfg.issuedShares, 0);
+    const perLevel = Math.max(remaining / L, 0.05); // ~small clips
+    for (let i=0;i<L;i++) {
+      const p = +(p0 * (1 + i*0.005)).toFixed(6); // 0.5% ticks up
+      this.addLevel(this.asks, p, perLevel, "ask");
+    }
+    // Seed bids for price discovery
+    const bidFloat = this.cfg.issuedShares * 0.5; // assume holders place some bids
+    const perBid = Math.max(bidFloat / L, 0.03);
+    for (let i=1;i<=L;i++) {
+      const p = +(p0 * (1 - i*0.005)).toFixed(6);
+      this.addLevel(this.bids, p, perBid, "bid");
+    }
+    this.lastPrice = p0;
+  }
+
+  // ---- analytics ----
+  vwap(hours = 24): number | undefined {
+    const cutoff = Date.now() - hours*3600_000;
+    let pv=0, v=0;
+    for (const t of this.trades) {
+      if (t.ts < cutoff) break;
+      pv += t.price * t.size; v += t.size;
+    }
+    return v > 0 ? pv/v : this.lastPrice;
+  }
+  twap(minutes = 5): number | undefined {
+    const cutoff = Date.now() - minutes*60_000;
+    const xs = this.trades.filter(t=>t.ts>=cutoff).map(t=>t.price);
+    if (!xs.length) return this.lastPrice;
+    return xs.reduce((a,b)=>a+b,0)/xs.length;
+  }
+  // Realized volatility (per-minute, last 60m), annualized
+  realizedVol(): number | undefined {
+    const cutoff = Date.now()-60*60_000;
+    const ts = this.trades.filter(t=>t.ts>=cutoff).map(t=>t.price);
+    if (ts.length<2) return undefined;
+    const rets = [];
+    for (let i=1;i<ts.length;i++) rets.push(Math.log(ts[i]/ts[i-1]));
+    const mu = rets.reduce((a,b)=>a+b,0)/rets.length;
+    const varr = rets.reduce((a,b)=>a+(b-mu)*(b-mu),0)/(rets.length-1);
+    // minute -> annualize (525600 minutes)
+    return Math.sqrt(varr) * Math.sqrt(525600);
+  }
+}

--- a/frontend/src/features/sodaspot/store.ts
+++ b/frontend/src/features/sodaspot/store.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+import { Engine, MarketConfig, Trade, Book } from "./engine";
+
+type Candle = { t: number; o: number; h: number; l: number; c: number };
+type State = {
+  engine: Engine;
+  book?: Book;
+  trades: Trade[];
+  candles: Candle[];
+  last?: number;
+  vwap?: number;
+  twap?: number;
+  vol?: number;
+};
+
+export const makeEngine = (cfg: MarketConfig) => new Engine(cfg);
+
+function buildCandle(c: Candle | undefined, price: number, ts: number): Candle {
+  const bucket = Math.floor(ts/60000)*60000;
+  if (!c || c.t !== bucket) return { t: bucket, o: price, h: price, l: price, c: price };
+  return { t: c.t, o: c.o, h: Math.max(c.h, price), l: Math.min(c.l, price), c: price };
+}
+
+export const useSoda = create<State>(() => ({
+  engine: makeEngine({ totalShares: 10, issuedShares: 3, treasuryAskPrice: 0.25 }),
+  trades: [],
+  candles: [],
+}));
+
+export function refresh() {
+  const e = useSoda.getState().engine;
+  const book = e.getBook();
+  const trades = e.getTrades();
+  let candles = useSoda.getState().candles.slice();
+  if (trades[0]) {
+    const lastC = candles[0];
+    const next = buildCandle(lastC, trades[0].price, trades[0].ts);
+    candles = lastC && lastC.t === next.t ? [next, ...candles.slice(1)] : [next, ...candles].slice(0, 500);
+  }
+  useSoda.setState({
+    book, trades, candles,
+    last: e.getLastPrice(),
+    vwap: e.vwap(24),
+    twap: e.twap(5),
+    vol: e.realizedVol()
+  });
+}
+
+export function place(params: { side: "buy"|"sell"; type: "limit"|"market"; price?: number; size: number }) {
+  const e = useSoda.getState().engine;
+  e.place({ id: crypto.randomUUID(), ts: Date.now(), ...params });
+  refresh();
+}

--- a/frontend/src/pages/ItemDetail.tsx
+++ b/frontend/src/pages/ItemDetail.tsx
@@ -23,20 +23,13 @@ import {
   Stack,
   Link,
 } from "@chakra-ui/react";
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip as ChartTooltip,
-  ResponsiveContainer,
-} from "recharts";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
 import axios from "../utils/axiosConfig";
 import itemsData from "../mocks/items.json";
 import assetsData from "../mocks/assets.json";
 import { formatAddress } from "../utils/formatAddress";
+import SodaSpot from "@/features/sodaspot/SodaSpot";
 
 type MarketDatum = { price: number; timestamp: string };
 
@@ -73,7 +66,6 @@ const ItemDetail: React.FC = () => {
   const [sharesOwned, setSharesOwned] = useState<number | null>(null);
   const [calcShares, setCalcShares] = useState<string>("");
   const [calcEarnings, setCalcEarnings] = useState<string>("");
-  const [marketData, setMarketData] = useState<MarketDatum[]>([]);
   const [latestPrice, setLatestPrice] = useState<number | null>(null);
 
   useEffect(() => {
@@ -111,7 +103,6 @@ const ItemDetail: React.FC = () => {
       try {
         const res = await axios.get(`/asset/market-data/${id}`);
         const data = res.data as MarketDatum;
-        setMarketData((prev) => [...prev.slice(-19), data]);
         setLatestPrice(data.price);
       } catch (err) {
         console.error("Failed to load market data:", err);
@@ -251,32 +242,12 @@ const ItemDetail: React.FC = () => {
         <Divider />
 
         <Stack direction={{ base: "column", md: "row" }} spacing={6}>
-          <Box
-            flex="1"
-            bg="rgba(12, 18, 38, 0.9)"
-            borderRadius="2xl"
-            border="1px solid rgba(114, 140, 255, 0.2)"
-            p={4}
-            minH="260px"
-          >
-            {marketData.length === 0 ? (
-              <Text color="whiteAlpha.600">Streaming market data…</Text>
-            ) : (
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={marketData}>
-                  <XAxis dataKey="timestamp" hide />
-                  <YAxis stroke="#cbd5f5" tick={{ fill: "#cbd5f5" }} />
-                  <ChartTooltip />
-                  <Line
-                    type="monotone"
-                    dataKey="price"
-                    stroke="#7c3aed"
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-            )}
+          <Box flex="1" minH="260px">
+            <SodaSpot
+              totalShares={asset.totalShares}
+              issuedShares={mintedSoFar ?? 0}
+              treasuryAskPrice={sharePriceSol}
+            />
           </Box>
 
           <VStack


### PR DESCRIPTION
## Summary
- add a lightweight CLOB engine, zustand store, and candlestick chart for SodaPop spot trading
- build ticket, order book, trades, and metrics panels wired into the new engine
- embed the new SodaSpot market surface on the item detail page and install lightweight-charts and zustand

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d613b8cb2c8327a6895b4c2fa5375a